### PR TITLE
Fixed `KeyError` on running `Docker-Compose` in hydrus

### DIFF
--- a/hydra_python_core/doc_maker.py
+++ b/hydra_python_core/doc_maker.py
@@ -240,11 +240,9 @@ def create_property(supported_prop: Dict[str, Any]) -> HydraClassProp:
     doc_keys = {
         "property": False,
         "title": False,
-        "readable": True,
-        "writeable": True,
         "required": True
     }
-    result = {}
+    result = {"readable": True,"writeable": True,}
     for k, literal in doc_keys.items():
         result[k] = input_key_check(
             supported_prop, k, "supported_prop", literal)
@@ -367,11 +365,14 @@ def create_operation(supported_op: Dict[str, Any]) -> HydraClassOp:
         "method": False,
         "expects": True,
         "returns": True,
-        "expectsHeader": False,
-        "returnsHeader": False,
         "possibleStatus": False
     }
-    result = {}
+    result = {"expectsHeader": [], "returnsHeader": []}
+    if "expectsHeader" in supported_op:
+        doc_keys["expectsHeader"] = False
+    if "returnsHeader" in supported_op:
+        doc_keys["returnsHeader"] = False
+
     for k, literal in doc_keys.items():
         result[k] = input_key_check(supported_op, k, "supported_op", literal)
     possible_statuses = list()
@@ -391,11 +392,12 @@ def create_status(possible_status: Dict[str, Any]) -> HydraStatus:
     """Create a HydraStatus object from the possibleStatus."""
     # Syntax checks
     doc_keys = {
-        "title": False,
         "statusCode": False,
         "description": True
     }
-    result = {}
+    result = {"title": ""}
+    if "title" in possible_status:
+        doc_keys["title"] = False;
     for k, literal in doc_keys.items():
         result[k] = input_key_check(
             possible_status, k, "possible_status", literal)


### PR DESCRIPTION
<!-- Please create/claim an issue before sending a PR -->
<!-- Add issue number (Eg: fixes #123) -->

Fixes #
KeyError

### Checklist
- [x] My branch is up-to-date with upstream/develop branch.
- [x] Everything works and tested for Python 3.5.2 and above.

### Description
<!-- Describe about what this PR does, previous state and new state of the output -->
While running `docker-compose up --build` on `hydrus`, it encountered some errors.  
The entire Traceback is [here](https://pastebin.com/YG4p68Lp)
### Change logs

<!-- #### Added -->
<!-- Edit these points below to describe the new features added with this PR -->
<!-- - Feature 1 -->
<!-- - Feature 2 -->

- `result = {"readable": True,"writeable": True,}` 
The default value of readable and writeable as mentioned in doc_keys. This is not of much use as the body contains `readonly` and `writeonly` keys.

- `    result = {"expectsHeader": [], "returnsHeader": []}
    if "expectsHeader" in supported_op: doc_keys["expectsHeader"] = False
    if "returnsHeader" in supported_op:  doc_keys["returnsHeader"] = False`
We check if both the keys are present in the dict, if yes then the default value is overridden.

- `    result = {"title": ""}
    if "title" in possible_status:
        doc_keys["title"] = False;`
Same as above

<!-- #### Changed -->
<!-- Edit these points below to describe the changes made in existing functionality with this PR -->
<!-- - Change 1 -->
<!-- - Change 1 -->


<!-- #### Fixed -->
<!-- Edit these points below to describe the bug fixes made with this PR -->
<!-- - Bug 1 -->


<!-- #### Removed -->
<!-- Edit these points below to describe the removed features with this PR -->
<!-- - Deprecated feature 1 -->
