### PR TITLE
FIX: Incomplete contexts in hydrus demo

### DIFF
--- a/hydra_python_core/doc_writer.py
+++ b/hydra_python_core/doc_writer.py
@@ -562,10 +562,10 @@ class IriTemplateMapping():
     def generate(self) -> Dict[str, Any]:
         """Get IriTemplateMapping as a python dict"""
         iri_template_mapping = {
-            "@type": "IriTemplateMapping",
-            "variable": self.variable,
-            "property": self.prop,
-            "required": self.required
+            "@type": "hydra:IriTemplateMapping",
+            "hydra:variable": self.variable,
+            "hydra:property": self.prop,
+            "hydra:required": self.required
         }
         return iri_template_mapping
 
@@ -587,10 +587,10 @@ class HydraIriTemplate():
     def generate(self) -> Dict[str, Any]:
         """Get IriTemplate as a python dict"""
         iri_template = {
-            "@type": "IriTemplate",
-            "template": self.template,
-            "variableRepresentation": self.variable_rep,
-            "mapping": [x.generate() for x in self.mapping]
+            "@type": "hydra:IriTemplate",
+            "hydra:template": self.template,
+            "hydra:variableRepresentation": self.variable_rep,
+            "hydra:mapping": [x.generate() for x in self.mapping]
         }
         return iri_template
 
@@ -757,7 +757,8 @@ class Context():
                 "subClassOf": {
                     "@id": "rdfs:subClassOf",
                     "@type": "@id"
-                }
+                },
+                "search": "hydra:search"
             }
 
     def createContext(self, object_: Dict[str, Any]) -> None:

--- a/samples/doc_writer_sample_output.py
+++ b/samples/doc_writer_sample_output.py
@@ -35,6 +35,7 @@ doc = {
             "@type": "@id"
         },
         "returnsHeader": "hydra:returnsHeader",
+        "search": "hydra:search",
         "statusCode": "hydra:statusCode",
         "subClassOf": {
             "@id": "rdfs:subClassOf",
@@ -53,10 +54,67 @@ doc = {
     "possibleStatus": [],
     "supportedClass": [
         {
-            "@id": "vocab:anotherSingleClass",
+            "@id": "vocab:dummyClass",
             "@type": "hydra:Class",
-            "description": "An another non collection class",
+            "description": "A dummyClass for demo",
             "supportedOperation": [
+                {
+                    "@type": "http://schema.org/UpdateAction",
+                    "expects": "vocab:dummyClass",
+                    "expectsHeader": [],
+                    "method": "POST",
+                    "possibleStatus": [
+                        {
+                            "@context": "http://www.w3.org/ns/hydra/context.jsonld",
+                            "@type": "Status",
+                            "description": "dummyClass updated.",
+                            "statusCode": 200,
+                            "title": ""
+                        }
+                    ],
+                    "returns": "null",
+                    "returnsHeader": [
+                        "Content-Type",
+                        "Content-Length"
+                    ],
+                    "title": "UpdateClass"
+                },
+                {
+                    "@type": "http://schema.org/DeleteAction",
+                    "expects": "null",
+                    "expectsHeader": [],
+                    "method": "DELETE",
+                    "possibleStatus": [
+                        {
+                            "@context": "http://www.w3.org/ns/hydra/context.jsonld",
+                            "@type": "Status",
+                            "description": "dummyClass deleted.",
+                            "statusCode": 200,
+                            "title": ""
+                        }
+                    ],
+                    "returns": "null",
+                    "returnsHeader": [],
+                    "title": "DeleteClass"
+                },
+                {
+                    "@type": "http://schema.org/AddAction",
+                    "expects": "vocab:dummyClass",
+                    "expectsHeader": [],
+                    "method": "PUT",
+                    "possibleStatus": [
+                        {
+                            "@context": "http://www.w3.org/ns/hydra/context.jsonld",
+                            "@type": "Status",
+                            "description": "dummyClass successfully added.",
+                            "statusCode": 201,
+                            "title": ""
+                        }
+                    ],
+                    "returns": "null",
+                    "returnsHeader": [],
+                    "title": "AddClass"
+                },
                 {
                     "@type": "http://schema.org/FindAction",
                     "expects": "null",
@@ -66,12 +124,12 @@ doc = {
                         {
                             "@context": "http://www.w3.org/ns/hydra/context.jsonld",
                             "@type": "Status",
-                            "description": "anotherSingleClass returned.",
+                            "description": "dummyClass returned.",
                             "statusCode": 200,
                             "title": ""
                         }
                     ],
-                    "returns": "vocab:anotherSingleClass",
+                    "returns": "vocab:dummyClass",
                     "returnsHeader": [],
                     "title": "GetClass"
                 }
@@ -84,9 +142,17 @@ doc = {
                     "required": "false",
                     "title": "Prop1",
                     "writeable": "true"
+                },
+                {
+                    "@type": "SupportedProperty",
+                    "property": "http://props.hydrus.com/prop1",
+                    "readable": "false",
+                    "required": "false",
+                    "title": "Prop2",
+                    "writeable": "true"
                 }
             ],
-            "title": "anotherSingleClass"
+            "title": "dummyClass"
         },
         {
             "@id": "vocab:extraClass",
@@ -219,67 +285,10 @@ doc = {
             "title": "singleClass"
         },
         {
-            "@id": "vocab:dummyClass",
+            "@id": "vocab:anotherSingleClass",
             "@type": "hydra:Class",
-            "description": "A dummyClass for demo",
+            "description": "An another non collection class",
             "supportedOperation": [
-                {
-                    "@type": "http://schema.org/UpdateAction",
-                    "expects": "vocab:dummyClass",
-                    "expectsHeader": [],
-                    "method": "POST",
-                    "possibleStatus": [
-                        {
-                            "@context": "http://www.w3.org/ns/hydra/context.jsonld",
-                            "@type": "Status",
-                            "description": "dummyClass updated.",
-                            "statusCode": 200,
-                            "title": ""
-                        }
-                    ],
-                    "returns": "null",
-                    "returnsHeader": [
-                        "Content-Type",
-                        "Content-Length"
-                    ],
-                    "title": "UpdateClass"
-                },
-                {
-                    "@type": "http://schema.org/DeleteAction",
-                    "expects": "null",
-                    "expectsHeader": [],
-                    "method": "DELETE",
-                    "possibleStatus": [
-                        {
-                            "@context": "http://www.w3.org/ns/hydra/context.jsonld",
-                            "@type": "Status",
-                            "description": "dummyClass deleted.",
-                            "statusCode": 200,
-                            "title": ""
-                        }
-                    ],
-                    "returns": "null",
-                    "returnsHeader": [],
-                    "title": "DeleteClass"
-                },
-                {
-                    "@type": "http://schema.org/AddAction",
-                    "expects": "vocab:dummyClass",
-                    "expectsHeader": [],
-                    "method": "PUT",
-                    "possibleStatus": [
-                        {
-                            "@context": "http://www.w3.org/ns/hydra/context.jsonld",
-                            "@type": "Status",
-                            "description": "dummyClass successfully added.",
-                            "statusCode": 201,
-                            "title": ""
-                        }
-                    ],
-                    "returns": "null",
-                    "returnsHeader": [],
-                    "title": "AddClass"
-                },
                 {
                     "@type": "http://schema.org/FindAction",
                     "expects": "null",
@@ -289,12 +298,12 @@ doc = {
                         {
                             "@context": "http://www.w3.org/ns/hydra/context.jsonld",
                             "@type": "Status",
-                            "description": "dummyClass returned.",
+                            "description": "anotherSingleClass returned.",
                             "statusCode": 200,
                             "title": ""
                         }
                     ],
-                    "returns": "vocab:dummyClass",
+                    "returns": "vocab:anotherSingleClass",
                     "returnsHeader": [],
                     "title": "GetClass"
                 }
@@ -307,17 +316,9 @@ doc = {
                     "required": "false",
                     "title": "Prop1",
                     "writeable": "true"
-                },
-                {
-                    "@type": "SupportedProperty",
-                    "property": "http://props.hydrus.com/prop1",
-                    "readable": "false",
-                    "required": "false",
-                    "title": "Prop2",
-                    "writeable": "true"
                 }
             ],
-            "title": "dummyClass"
+            "title": "anotherSingleClass"
         },
         {
             "@id": "http://www.w3.org/ns/hydra/core#Resource",
@@ -343,56 +344,6 @@ doc = {
                 }
             ],
             "title": "Collection"
-        },
-        {
-            "@id": "vocab:extraClassCollection",
-            "@type": "hydra:Class",
-            "description": "A collection of extraclass",
-            "subClassOf": "http://www.w3.org/ns/hydra/core#Collection",
-            "supportedOperation": [
-                {
-                    "@id": "_:extraclass_collection_retrieve",
-                    "@type": "http://schema.org/FindAction",
-                    "description": "Retrieves all extraClass entities",
-                    "expects": "null",
-                    "expectsHeader": [],
-                    "method": "GET",
-                    "possibleStatus": [],
-                    "returns": "vocab:extraClassCollection",
-                    "returnsHeader": []
-                },
-                {
-                    "@id": "_:extraclass_create",
-                    "@type": "http://schema.org/AddAction",
-                    "description": "Create new extraClass entity",
-                    "expects": "vocab:extraClass",
-                    "expectsHeader": [],
-                    "method": "PUT",
-                    "possibleStatus": [
-                        {
-                            "@context": "http://www.w3.org/ns/hydra/context.jsonld",
-                            "@type": "Status",
-                            "description": "If the extraClass entity was createdsuccessfully.",
-                            "statusCode": 201,
-                            "title": ""
-                        }
-                    ],
-                    "returns": "vocab:extraClass",
-                    "returnsHeader": []
-                }
-            ],
-            "supportedProperty": [
-                {
-                    "@type": "SupportedProperty",
-                    "description": "The extraclass",
-                    "property": "http://www.w3.org/ns/hydra/core#member",
-                    "readable": "false",
-                    "required": "false",
-                    "title": "members",
-                    "writeable": "false"
-                }
-            ],
-            "title": "extraClassCollection"
         },
         {
             "@id": "vocab:dummyClassCollection",
@@ -445,6 +396,56 @@ doc = {
             "title": "dummyClassCollection"
         },
         {
+            "@id": "vocab:extraClassCollection",
+            "@type": "hydra:Class",
+            "description": "A collection of extraclass",
+            "subClassOf": "http://www.w3.org/ns/hydra/core#Collection",
+            "supportedOperation": [
+                {
+                    "@id": "_:extraclass_collection_retrieve",
+                    "@type": "http://schema.org/FindAction",
+                    "description": "Retrieves all extraClass entities",
+                    "expects": "null",
+                    "expectsHeader": [],
+                    "method": "GET",
+                    "possibleStatus": [],
+                    "returns": "vocab:extraClassCollection",
+                    "returnsHeader": []
+                },
+                {
+                    "@id": "_:extraclass_create",
+                    "@type": "http://schema.org/AddAction",
+                    "description": "Create new extraClass entity",
+                    "expects": "vocab:extraClass",
+                    "expectsHeader": [],
+                    "method": "PUT",
+                    "possibleStatus": [
+                        {
+                            "@context": "http://www.w3.org/ns/hydra/context.jsonld",
+                            "@type": "Status",
+                            "description": "If the extraClass entity was createdsuccessfully.",
+                            "statusCode": 201,
+                            "title": ""
+                        }
+                    ],
+                    "returns": "vocab:extraClass",
+                    "returnsHeader": []
+                }
+            ],
+            "supportedProperty": [
+                {
+                    "@type": "SupportedProperty",
+                    "description": "The extraclass",
+                    "property": "http://www.w3.org/ns/hydra/core#member",
+                    "readable": "false",
+                    "required": "false",
+                    "title": "members",
+                    "writeable": "false"
+                }
+            ],
+            "title": "extraClassCollection"
+        },
+        {
             "@id": "vocab:EntryPoint",
             "@type": "hydra:Class",
             "description": "The main entry point or homepage of the API.",
@@ -462,43 +463,6 @@ doc = {
                 }
             ],
             "supportedProperty": [
-                {
-                    "hydra:description": "The anotherSingleClass Class",
-                    "hydra:title": "anothersingleclass",
-                    "property": {
-                        "@id": "vocab:EntryPoint/anotherSingleClass",
-                        "@type": "hydra:Link",
-                        "description": "An another non collection class",
-                        "domain": "vocab:EntryPoint",
-                        "label": "anotherSingleClass",
-                        "range": "vocab:anotherSingleClass",
-                        "supportedOperation": [
-                            {
-                                "@id": "getclass",
-                                "@type": "http://schema.org/FindAction",
-                                "description": "null",
-                                "expects": "null",
-                                "expectsHeader": [],
-                                "label": "GetClass",
-                                "method": "GET",
-                                "possibleStatus": [
-                                    {
-                                        "@context": "http://www.w3.org/ns/hydra/context.jsonld",
-                                        "@type": "Status",
-                                        "description": "anotherSingleClass returned.",
-                                        "statusCode": 200,
-                                        "title": ""
-                                    }
-                                ],
-                                "returns": "vocab:anotherSingleClass",
-                                "returnsHeader": []
-                            }
-                        ]
-                    },
-                    "readable": "true",
-                    "required": "null",
-                    "writeable": "false"
-                },
                 {
                     "hydra:description": "The singleClass Class",
                     "hydra:title": "singleclass",
@@ -597,44 +561,34 @@ doc = {
                     "writeable": "false"
                 },
                 {
-                    "hydra:description": "The extraClassCollection collection",
-                    "hydra:title": "extraclasscollection",
+                    "hydra:description": "The anotherSingleClass Class",
+                    "hydra:title": "anothersingleclass",
                     "property": {
-                        "@id": "vocab:EntryPoint/EcTest",
+                        "@id": "vocab:EntryPoint/anotherSingleClass",
                         "@type": "hydra:Link",
-                        "description": "The extraClassCollection collection",
+                        "description": "An another non collection class",
                         "domain": "vocab:EntryPoint",
-                        "label": "extraClassCollection",
-                        "range": "vocab:extraClassCollection",
+                        "label": "anotherSingleClass",
+                        "range": "vocab:anotherSingleClass",
                         "supportedOperation": [
                             {
-                                "@id": "_:extraclass_collection_retrieve",
+                                "@id": "getclass",
                                 "@type": "http://schema.org/FindAction",
-                                "description": "Retrieves all extraClass entities",
+                                "description": "null",
                                 "expects": "null",
                                 "expectsHeader": [],
+                                "label": "GetClass",
                                 "method": "GET",
-                                "possibleStatus": [],
-                                "returns": "vocab:extraClassCollection",
-                                "returnsHeader": []
-                            },
-                            {
-                                "@id": "_:extraclass_create",
-                                "@type": "http://schema.org/AddAction",
-                                "description": "Create new extraClass entity",
-                                "expects": "vocab:extraClass",
-                                "expectsHeader": [],
-                                "method": "PUT",
                                 "possibleStatus": [
                                     {
                                         "@context": "http://www.w3.org/ns/hydra/context.jsonld",
                                         "@type": "Status",
-                                        "description": "If the extraClass entity was createdsuccessfully.",
-                                        "statusCode": 201,
+                                        "description": "anotherSingleClass returned.",
+                                        "statusCode": 200,
                                         "title": ""
                                     }
                                 ],
-                                "returns": "vocab:extraClass",
+                                "returns": "vocab:anotherSingleClass",
                                 "returnsHeader": []
                             }
                         ]
@@ -682,6 +636,53 @@ doc = {
                                     }
                                 ],
                                 "returns": "vocab:dummyClass",
+                                "returnsHeader": []
+                            }
+                        ]
+                    },
+                    "readable": "true",
+                    "required": "null",
+                    "writeable": "false"
+                },
+                {
+                    "hydra:description": "The extraClassCollection collection",
+                    "hydra:title": "extraclasscollection",
+                    "property": {
+                        "@id": "vocab:EntryPoint/EcTest",
+                        "@type": "hydra:Link",
+                        "description": "The extraClassCollection collection",
+                        "domain": "vocab:EntryPoint",
+                        "label": "extraClassCollection",
+                        "range": "vocab:extraClassCollection",
+                        "supportedOperation": [
+                            {
+                                "@id": "_:extraclass_collection_retrieve",
+                                "@type": "http://schema.org/FindAction",
+                                "description": "Retrieves all extraClass entities",
+                                "expects": "null",
+                                "expectsHeader": [],
+                                "method": "GET",
+                                "possibleStatus": [],
+                                "returns": "vocab:extraClassCollection",
+                                "returnsHeader": []
+                            },
+                            {
+                                "@id": "_:extraclass_create",
+                                "@type": "http://schema.org/AddAction",
+                                "description": "Create new extraClass entity",
+                                "expects": "vocab:extraClass",
+                                "expectsHeader": [],
+                                "method": "PUT",
+                                "possibleStatus": [
+                                    {
+                                        "@context": "http://www.w3.org/ns/hydra/context.jsonld",
+                                        "@type": "Status",
+                                        "description": "If the extraClass entity was createdsuccessfully.",
+                                        "statusCode": 201,
+                                        "title": ""
+                                    }
+                                ],
+                                "returns": "vocab:extraClass",
                                 "returnsHeader": []
                             }
                         ]


### PR DESCRIPTION
Fixes https://github.com/HTTP-APIs/hydrus/issues/429

<!-- Please create/claim an issue before sending a PR -->
<!-- Add issue number (Eg: fixes #123) -->

### Checklist
- [x] My branch is up-to-date with upstream/develop branch.
- [x] Everything works and tested for Python 3.5.2 and above.

### Description
<!-- Describe about what this PR does, previous state and new state of the output -->
Add context to the given classes/properties: `IriTemplateMapping`, `variable`,
`property`, `required`, `IriTemplate`, `template`, `variableRepresentation`,
`mapping` and `search` by prefixing them with `hydra:`.

NOTE: This PR complements https://github.com/HTTP-APIs/hydrus/pull/441.


### Change logs

<!-- #### Added -->
<!-- Edit these points below to describe the new features added with this PR -->
<!-- - Feature 1 -->
<!-- - Feature 2 -->


<!-- #### Changed -->
<!-- Edit these points below to describe the changes made in existing functionality with this PR -->
<!-- - Change 1 -->
<!-- - Change 1 -->


<!-- #### Fixed -->
<!-- Edit these points below to describe the bug fixes made with this PR -->
<!-- - Bug 1 -->


<!-- #### Removed -->
<!-- Edit these points below to describe the removed features with this PR -->
<!-- - Deprecated feature 1 -->
