### PR TITLE
Remove dependency of class collection

### DIFF
--- a/hydra_python_core/doc_writer.py
+++ b/hydra_python_core/doc_writer.py
@@ -282,21 +282,21 @@ class HydraCollection():
         self.manages = manages
 
         if get:
-            get_op = HydraCollectionOp("{}{}_retrieve".format(DocUrl.doc_url, self.name),
+            get_op = HydraCollectionOp("_:{}_retrieve".format(self.name),
                                        "http://schema.org/FindAction",
                                        "GET", "Retrieves all the members of {}".format(self.name),
                                        None, self.manages['object'], [], [], [])
             self.supportedOperation.append(get_op)
 
         if put:
-            put_op = HydraCollectionOp("{}{}_create".format(DocUrl.doc_url, self.name), "http://schema.org/AddAction",
+            put_op = HydraCollectionOp("_:{}_create".format(self.name), "http://schema.org/AddAction",
                                        "PUT", "Create new member in {}".format(self.name),
                                        self.manages['object'], self.manages['object'], [], [],
                                        [HydraStatus(code=201, desc="A new member in {} created".format(self.name))]
                                        )
             self.supportedOperation.append(put_op)
         if post:
-            post_op = HydraCollectionOp("{}{}_update".format(DocUrl.doc_url, self.name),
+            post_op = HydraCollectionOp("_:{}_update".format(self.name),
                                         "http://schema.org/UpdateAction",
                                         "POST", "Update member of  {} ".format(self.name),
                                         self.manages['object'], self.manages['object'], [], [],
@@ -306,7 +306,7 @@ class HydraCollection():
             self.supportedOperation.append(post_op)
 
         if delete:
-            delete_op = HydraCollectionOp("{}{}_delete".format(DocUrl.doc_url, self.name),
+            delete_op = HydraCollectionOp("_:{}_delete".format(self.name),
                                           "http://schema.org/DeleteAction",
                                           "DELETE", "Delete member of {} ".format(self.name),
                                           self.manages['object'], self.manages['object'], [], [],
@@ -382,7 +382,7 @@ class HydraEntryPoint():
         self.entrypoint = HydraClass(
             "EntryPoint", "EntryPoint", "The main entry point or homepage of the API.")
         self.entrypoint.add_supported_op(EntryPointOp(
-            "{}entry_point".format(base_url), "GET", "The APIs main entry point.", None, None,
+            "_:entry_point".format(base_url), "GET", "The APIs main entry point.", None, None,
             type_="{}EntryPoint".format(DocUrl.doc_url)))
         self.context = Context(
             "{}{}".format(

--- a/hydra_python_core/doc_writer.py
+++ b/hydra_python_core/doc_writer.py
@@ -50,6 +50,21 @@ class HydraDoc():
                 "context": Context(address="{}{}".format(self.base_url, self.API),
                                    collection=collection), "collection": collection}
 
+    def add_supported_collection(self, collection_: 'HydraCollection') -> None:
+        """Add a supported Collection
+
+        Raises:
+            TypeError: If `collection_` is not an instance of `HydraCollection`
+
+        """
+
+        if not isinstance(collection_, HydraCollection):
+            raise TypeError("Type is not <HydraCollection>")
+
+        self.collections[collection_.path] = {
+            "context": Context(address="{}{}".format(self.base_url, self.API),
+                               collection=collection_), "collection": collection_}
+
     def add_possible_status(self, status: Union['HydraStatus', 'HydraError']) -> None:
         """Add a new possibleStatus.
 
@@ -383,7 +398,7 @@ class HydraCollectionOp():
         return object_
 
 
-class HydraEntryPoint():
+class HydraEntryPoint(HydraClass):
     """Template for a new entrypoint."""
 
     def __init__(self, base_url: str, entrypoint: str) -> None:

--- a/hydra_python_core/doc_writer.py
+++ b/hydra_python_core/doc_writer.py
@@ -763,6 +763,18 @@ class Context():
                     "@id": "hydra:returns",
                     "@type": "@id"
                 },
+                "entrypoint": {
+                    "@id": "hydra:entrypoint",
+                    "@type": "@id"
+                },
+                "object": {
+                    "@id": "hydra:object",
+                    "@type": "@id"
+                },
+                "subject": {
+                    "@id": "hydra:subject",
+                    "@type": "@id"
+                },
                 "readable": "hydra:readable",
                 "writeable": "hydra:writeable",
                 "possibleStatus": "hydra:possibleStatus",

--- a/hydra_python_core/doc_writer.py
+++ b/hydra_python_core/doc_writer.py
@@ -30,25 +30,12 @@ class HydraDoc():
             TypeError: If `class_` is not an instance of `HydraClass`
 
         """
-        # collection: Union[bool, 'HydraCollection']=False,
-        #    collection_name: str=None,
-        #   collection_path: str=None, collectionGet: bool=True, collectionPost: bool=True,
-        #  collection_manages: Union[Dict[str, Any], List]=None
-        # self.doc["supportedClass"].append(class_.get())
         if not isinstance(class_, HydraClass):
             raise TypeError("Type is not <HydraClass>")
         self.parsed_classes[class_.path] = {
             "context": Context(address="{}{}".format(self.base_url, self.API), class_=class_),
             "class": class_,
-            # "collection": collection
         }
-        # if collection:
-        #     collection = HydraCollection(
-        #         class_, collection_name, collection_path, collection_manages, collectionGet,
-        #         collectionPost)
-        #     self.collections[collection.path] = {
-        #         "context": Context(address="{}{}".format(self.base_url, self.API),
-        #                            collection=collection), "collection": collection}
 
     def add_supported_collection(self, collection_: 'HydraCollection') -> None:
         """Add a supported Collection

--- a/samples/doc_writer_sample.py
+++ b/samples/doc_writer_sample.py
@@ -1,8 +1,9 @@
 """Sample to create Hydra APIDocumentation using doc_writer."""
 
 from hydra_python_core.doc_writer import (HydraDoc, HydraClass, HydraClassProp, HydraClassOp,
-                                            HydraStatus, HydraError, HydraLink)
+                                            HydraStatus, HydraError, HydraLink,HydraCollection)
 from typing import Any, Dict, Union
+from urllib.parse import urljoin
 
 # Creating the HydraDoc object, this is the primary class for the Doc
 API_NAME = "api"                # Name of the API, will serve as EntryPoint
@@ -19,13 +20,14 @@ api_doc = HydraDoc(API_NAME,
 
 
 # Creating classes for the API
-class_uri = "dummyClass"      # URI of class for the HydraClass
+class_uri = urljoin(BASE_URL, API_NAME + "/dummyClass")      # URI of class for the HydraClass
 class_title = "dummyClass"                      # Title of the Class
 class_description = "A dummyClass for demo"     # Description of the class
 class_ = HydraClass(class_uri, class_title, class_description, endpoint=False)
 
+
 # Class with single instance
-class_2_uri = "singleClass"
+class_2_uri = urljoin(BASE_URL, API_NAME + "/singleClass")
 class_2_title = "singleClass"
 class_2_description = "A non collection class"
 class_2 = HydraClass(class_2_uri, class_2_title,
@@ -33,18 +35,45 @@ class_2 = HydraClass(class_2_uri, class_2_title,
 
 # Another class with single instance, will be used as nested class
 
-class_1_uri = "anotherSingleClass"
+class_1_uri = urljoin(BASE_URL, API_NAME + "/anotherSingleClass")
 class_1_title = "anotherSingleClass"
 class_1_description = "An another non collection class"
 class_1 = HydraClass(class_1_uri, class_1_title,
                      class_1_description, endpoint=True)
 
 # Class not having any methods except put and get
-class_3_uri = "extraClass"
+class_3_uri = urljoin(BASE_URL, API_NAME + "/extraClass")
 class_3_title = "extraClass"
 class_3_description = "Class without any explicit methods"
 class_3 = HydraClass(class_3_uri, class_3_title,
                      class_3_description, endpoint=False)
+
+collection_uri = urljoin(BASE_URL, API_NAME + "/collection_1")
+collection_name = "Extraclasses"
+collection_title = "ExtraClass collection"
+collection_description = "This collection comprises of instances of ExtraClass"
+# add explicit statements about members of the collection
+# Following manages block means every member of this collection is of type class_3
+collection_managed_by = {
+    "property": "rdf:type",
+    "object": class_3_uri,
+}
+collection_1 = HydraCollection(collection_id=collection_uri, collection_name=collection_name,
+                               collection_description=collection_description, manages=collection_managed_by, get=True,
+                               post=True, collection_path="EcTest")
+
+collection2_uri = urljoin(BASE_URL, API_NAME + "/collection_2")
+collection2_title = "dummyClass collection"
+collection2_name = "dummyclasses"
+collection2_description = "This collection comprises of instances of dummyClass"
+collection2_managed_by = {
+    "property": "rdf:type",
+    "object": class_uri,
+}
+
+collection_2 = HydraCollection(collection_id=collection2_uri, collection_name=collection2_name,
+                               collection_description=collection2_description, manages=collection2_managed_by, get=True,
+                               post=True, collection_path="DcTest")
 
 # NOTE: Setting endpoint=True creates an endpoint for the class itself, this is usually for classes
 #       that have single instances.
@@ -75,7 +104,7 @@ dummyProp2 = HydraClassProp(prop1_uri, prop2_title,
 op_name = "UpdateClass"  # The name of the operation
 op_method = "POST"  # The method of the Operation [GET, POST, PUT, DELETE]
 # URI of the object that is expected for the operation
-op_expects = "vocab:dummyClass"
+op_expects = class_uri
 op_returns = None   # URI of the object that is returned by the operation
 op_returns_header = ["Content-Type", "Content-Length"]
 op_expects_header = []
@@ -94,38 +123,38 @@ op1 = HydraClassOp(op_name,
 op2_status = [HydraStatus(code=200, desc="dummyClass deleted.")]
 op2 = HydraClassOp("DeleteClass", "DELETE", None, None, [], [], op2_status)
 op3_status = [HydraStatus(code=201, desc="dummyClass successfully added.")]
-op3 = HydraClassOp("AddClass", "PUT", "vocab:dummyClass", None, [], [], op3_status)
+op3 = HydraClassOp("AddClass", "PUT", class_uri, None, [], [], op3_status)
 op4_status = [HydraStatus(code=200, desc="dummyClass returned.")]
-op4 = HydraClassOp("GetClass", "GET", None, "vocab:dummyClass", [], [], op4_status)
+op4 = HydraClassOp("GetClass", "GET", None, class_uri, [], [], op4_status)
 
 # Operations for non collection class
 class_2_op1_status = [HydraStatus(code=200, desc="singleClass changed.")]
 class_2_op1 = HydraClassOp("UpdateClass", "POST",
-                           "vocab:singleClass", None, [], [], class_2_op1_status)
+                           class_2_uri, None, [], [], class_2_op1_status)
 class_2_op2_status = [HydraStatus(code=200, desc="singleClass deleted.")]
 class_2_op2 = HydraClassOp("DeleteClass", "DELETE",
                            None, None, [], [], class_2_op2_status)
 class_2_op3_status = [HydraStatus(code=201, desc="singleClass successfully added.")]
 class_2_op3 = HydraClassOp(
-    "AddClass", "PUT", "vocab:singleClass", None, [], [], class_2_op3_status)
+    "AddClass", "PUT", class_2_uri, None, [], [], class_2_op3_status)
 class_2_op4_status = [HydraStatus(code=200, desc="singleClass returned.")]
 class_2_op4 = HydraClassOp("GetClass", "GET", None,
-                           "vocab:singleClass", [], [], class_2_op4_status)
+                           class_2_uri, [], [], class_2_op4_status)
 
 class_1_op1_status = [HydraStatus(code=200, desc="anotherSingleClass returned.")]
 class_1_op1 = HydraClassOp("GetClass", "GET", None,
-                           "vocab:anotherSingleClass", [], [], class_1_op1_status)
+                           class_1_uri, [], [], class_1_op1_status)
 # Add the properties to the classes
 class_.add_supported_prop(dummyProp1)
 class_.add_supported_prop(dummyProp2)
 class_2.add_supported_prop(dummyProp1)
 class_2.add_supported_prop(dummyProp2)
-dummy_prop_link = HydraLink("singleClass/dummyProp", "dummyProp", domain="vocab:singleClass",
-                            range_="vocab:dummyClass")
+dummy_prop_link = HydraLink("singleClass/dummyProp", "dummyProp", domain=class_2_uri,
+                            range_=class_uri)
 class_2.add_supported_prop(HydraClassProp(
     dummy_prop_link, "dummyProp", required=False, read=False, write=True))
 class_2.add_supported_prop(HydraClassProp(
-    "vocab:anotherSingleClass", "singleClassProp", required=False, read=False, write=True))
+    class_1_uri, "singleClassProp", required=False, read=False, write=True))
 class_1.add_supported_prop(dummyProp1)
 # Add the operations to the classes
 class_.add_supported_op(op1)
@@ -138,32 +167,20 @@ class_2.add_supported_op(class_2_op3)
 class_2.add_supported_op(class_2_op4)
 class_1.add_supported_op(class_1_op1)
 
-# add explicit statements about members of the collection
-# Following manages block means every member of this collection is of type class_
-collection_1_managed_by = {
-    "property": "rdf:type",
-    "object": 'vocab:' + class_uri,
-}
-# Following manages block means every member of this collection is of type class_3
-collection_3_managed_by = {
-    "property": "rdf:type",
-    "object": 'vocab:' + class_3_uri,
-}
 # Add the classes to the HydraDoc
 
-api_doc.add_supported_class(class_, collection=True, collection_path="DcTest",
-                            collection_manages=collection_1_managed_by)
-api_doc.add_supported_class(class_3, collection=True, collection_path="EcTest",
-                            collection_manages=collection_3_managed_by)
-api_doc.add_supported_class(class_2, collection=False)
-api_doc.add_supported_class(class_1, collection=False)
-# NOTE: Using collection=True creates a HydraCollection for the class.
-#       The name of the Collection is class_.title+"Collection"
-#       The collection inherently supports GET and PUT operations
+api_doc.add_supported_class(class_)
+api_doc.add_supported_class(class_3)
+# add the collection to the HydraDoc.
+api_doc.add_supported_collection(collection_1)
+api_doc.add_supported_collection(collection_2)
+api_doc.add_supported_class(class_2)
+api_doc.add_supported_class(class_1)
+api_doc.add_supported_class(class_1)
 
 # Other operations needed for the Doc
-api_doc.add_baseResource(
-)      # Creates the base Resource Class and adds it to the API Documentation
+# Creates the base Resource Class and adds it to the API Documentation
+api_doc.add_baseResource()
 # Creates the base Collection Class and adds it to the API Documentation
 api_doc.add_baseCollection()
 # Generates the EntryPoint object for the Doc using the Classes and Collections

--- a/samples/doc_writer_sample.py
+++ b/samples/doc_writer_sample.py
@@ -16,39 +16,36 @@ api_doc = HydraDoc(API_NAME,
                    "Title for the API Documentation",
                    "Description for the API Documentation",
                    API_NAME,
-                   BASE_URL)
+                   BASE_URL,
+                   "vocab")
 
 
 # Creating classes for the API
-class_uri = urljoin(BASE_URL, API_NAME + "/dummyClass")      # URI of class for the HydraClass
 class_title = "dummyClass"                      # Title of the Class
 class_description = "A dummyClass for demo"     # Description of the class
-class_ = HydraClass(class_uri, class_title, class_description, endpoint=False)
+class_ = HydraClass(class_title, class_description, endpoint=False)
 
 
 # Class with single instance
-class_2_uri = urljoin(BASE_URL, API_NAME + "/singleClass")
+
 class_2_title = "singleClass"
 class_2_description = "A non collection class"
-class_2 = HydraClass(class_2_uri, class_2_title,
+class_2 = HydraClass(class_2_title,
                      class_2_description, endpoint=True)
 
 # Another class with single instance, will be used as nested class
 
-class_1_uri = urljoin(BASE_URL, API_NAME + "/anotherSingleClass")
 class_1_title = "anotherSingleClass"
 class_1_description = "An another non collection class"
-class_1 = HydraClass(class_1_uri, class_1_title,
+class_1 = HydraClass(class_1_title,
                      class_1_description, endpoint=True)
 
 # Class not having any methods except put and get
-class_3_uri = urljoin(BASE_URL, API_NAME + "/extraClass")
 class_3_title = "extraClass"
 class_3_description = "Class without any explicit methods"
-class_3 = HydraClass(class_3_uri, class_3_title,
+class_3 = HydraClass(class_3_title,
                      class_3_description, endpoint=False)
 
-collection_uri = urljoin(BASE_URL, API_NAME + "/collection_1")
 collection_name = "Extraclasses"
 collection_title = "ExtraClass collection"
 collection_description = "This collection comprises of instances of ExtraClass"
@@ -56,22 +53,21 @@ collection_description = "This collection comprises of instances of ExtraClass"
 # Following manages block means every member of this collection is of type class_3
 collection_managed_by = {
     "property": "rdf:type",
-    "object": class_3_uri,
+    "object": class_3.id_,
 }
-collection_1 = HydraCollection(collection_id=collection_uri, collection_name=collection_name,
+collection_1 = HydraCollection(collection_name=collection_name,
                                collection_description=collection_description, manages=collection_managed_by, get=True,
                                post=True, collection_path="EcTest")
 
-collection2_uri = urljoin(BASE_URL, API_NAME + "/collection_2")
 collection2_title = "dummyClass collection"
 collection2_name = "dummyclasses"
 collection2_description = "This collection comprises of instances of dummyClass"
 collection2_managed_by = {
     "property": "rdf:type",
-    "object": class_uri,
+    "object": class_.id_,
 }
 
-collection_2 = HydraCollection(collection_id=collection2_uri, collection_name=collection2_name,
+collection_2 = HydraCollection(collection_name=collection2_name,
                                collection_description=collection2_description, manages=collection2_managed_by, get=True,
                                post=True, collection_path="DcTest")
 
@@ -104,7 +100,7 @@ dummyProp2 = HydraClassProp(prop1_uri, prop2_title,
 op_name = "UpdateClass"  # The name of the operation
 op_method = "POST"  # The method of the Operation [GET, POST, PUT, DELETE]
 # URI of the object that is expected for the operation
-op_expects = class_uri
+op_expects = class_.id_
 op_returns = None   # URI of the object that is returned by the operation
 op_returns_header = ["Content-Type", "Content-Length"]
 op_expects_header = []
@@ -123,38 +119,38 @@ op1 = HydraClassOp(op_name,
 op2_status = [HydraStatus(code=200, desc="dummyClass deleted.")]
 op2 = HydraClassOp("DeleteClass", "DELETE", None, None, [], [], op2_status)
 op3_status = [HydraStatus(code=201, desc="dummyClass successfully added.")]
-op3 = HydraClassOp("AddClass", "PUT", class_uri, None, [], [], op3_status)
+op3 = HydraClassOp("AddClass", "PUT", class_.id_, None, [], [], op3_status)
 op4_status = [HydraStatus(code=200, desc="dummyClass returned.")]
-op4 = HydraClassOp("GetClass", "GET", None, class_uri, [], [], op4_status)
+op4 = HydraClassOp("GetClass", "GET", None, class_.id_, [], [], op4_status)
 
 # Operations for non collection class
 class_2_op1_status = [HydraStatus(code=200, desc="singleClass changed.")]
 class_2_op1 = HydraClassOp("UpdateClass", "POST",
-                           class_2_uri, None, [], [], class_2_op1_status)
+                           class_2.id_, None, [], [], class_2_op1_status)
 class_2_op2_status = [HydraStatus(code=200, desc="singleClass deleted.")]
 class_2_op2 = HydraClassOp("DeleteClass", "DELETE",
                            None, None, [], [], class_2_op2_status)
 class_2_op3_status = [HydraStatus(code=201, desc="singleClass successfully added.")]
 class_2_op3 = HydraClassOp(
-    "AddClass", "PUT", class_2_uri, None, [], [], class_2_op3_status)
+    "AddClass", "PUT", class_2.id_, None, [], [], class_2_op3_status)
 class_2_op4_status = [HydraStatus(code=200, desc="singleClass returned.")]
 class_2_op4 = HydraClassOp("GetClass", "GET", None,
-                           class_2_uri, [], [], class_2_op4_status)
+                           class_2.id_, [], [], class_2_op4_status)
 
 class_1_op1_status = [HydraStatus(code=200, desc="anotherSingleClass returned.")]
 class_1_op1 = HydraClassOp("GetClass", "GET", None,
-                           class_1_uri, [], [], class_1_op1_status)
+                           class_1.id_, [], [], class_1_op1_status)
 # Add the properties to the classes
 class_.add_supported_prop(dummyProp1)
 class_.add_supported_prop(dummyProp2)
 class_2.add_supported_prop(dummyProp1)
 class_2.add_supported_prop(dummyProp2)
-dummy_prop_link = HydraLink("singleClass/dummyProp", "dummyProp", domain=class_2_uri,
-                            range_=class_uri)
+dummy_prop_link = HydraLink("singleClass/dummyProp", "dummyProp", domain=class_2.id_,
+                            range_=class_.id_)
 class_2.add_supported_prop(HydraClassProp(
     dummy_prop_link, "dummyProp", required=False, read=False, write=True))
 class_2.add_supported_prop(HydraClassProp(
-    class_1_uri, "singleClassProp", required=False, read=False, write=True))
+    class_1.id_, "singleClassProp", required=False, read=False, write=True))
 class_1.add_supported_prop(dummyProp1)
 # Add the operations to the classes
 class_.add_supported_op(op1)

--- a/samples/doc_writer_sample.py
+++ b/samples/doc_writer_sample.py
@@ -171,12 +171,13 @@ class_1.add_supported_op(class_1_op1)
 
 api_doc.add_supported_class(class_)
 api_doc.add_supported_class(class_3)
-# add the collection to the HydraDoc.
-api_doc.add_supported_collection(collection_1)
-api_doc.add_supported_collection(collection_2)
 api_doc.add_supported_class(class_2)
 api_doc.add_supported_class(class_1)
 api_doc.add_supported_class(class_1)
+
+# add the collection to the HydraDoc.
+api_doc.add_supported_collection(collection_1)
+api_doc.add_supported_collection(collection_2)
 
 # Other operations needed for the Doc
 # Creates the base Resource Class and adds it to the API Documentation

--- a/samples/doc_writer_sample_output.py
+++ b/samples/doc_writer_sample_output.py
@@ -368,7 +368,7 @@ doc = {
             "subClassOf": "http://www.w3.org/ns/hydra/core#Collection",
             "supportedOperation": [
                 {
-                    "@id": "https://hydrus.com/api/vocab#Extraclasses_retrieve",
+                    "@id": "_:Extraclasses_retrieve",
                     "@type": "http://schema.org/FindAction",
                     "description": "Retrieves all the members of Extraclasses",
                     "expects": "null",
@@ -379,7 +379,7 @@ doc = {
                     "returnsHeader": []
                 },
                 {
-                    "@id": "https://hydrus.com/api/vocab#Extraclasses_create",
+                    "@id": "_:Extraclasses_create",
                     "@type": "http://schema.org/AddAction",
                     "description": "Create new member in Extraclasses",
                     "expects": "https://hydrus.com/api/vocab#extraClass",
@@ -398,7 +398,7 @@ doc = {
                     "returnsHeader": []
                 },
                 {
-                    "@id": "https://hydrus.com/api/vocab#Extraclasses_update",
+                    "@id": "_:Extraclasses_update",
                     "@type": "http://schema.org/UpdateAction",
                     "description": "Update member of  Extraclasses ",
                     "expects": "https://hydrus.com/api/vocab#extraClass",
@@ -417,7 +417,7 @@ doc = {
                     "returnsHeader": []
                 },
                 {
-                    "@id": "https://hydrus.com/api/vocab#Extraclasses_delete",
+                    "@id": "_:Extraclasses_delete",
                     "@type": "http://schema.org/DeleteAction",
                     "description": "Delete member of Extraclasses ",
                     "expects": "https://hydrus.com/api/vocab#extraClass",
@@ -460,7 +460,7 @@ doc = {
             "subClassOf": "http://www.w3.org/ns/hydra/core#Collection",
             "supportedOperation": [
                 {
-                    "@id": "https://hydrus.com/api/vocab#dummyclasses_retrieve",
+                    "@id": "_:dummyclasses_retrieve",
                     "@type": "http://schema.org/FindAction",
                     "description": "Retrieves all the members of dummyclasses",
                     "expects": "null",
@@ -471,7 +471,7 @@ doc = {
                     "returnsHeader": []
                 },
                 {
-                    "@id": "https://hydrus.com/api/vocab#dummyclasses_create",
+                    "@id": "_:dummyclasses_create",
                     "@type": "http://schema.org/AddAction",
                     "description": "Create new member in dummyclasses",
                     "expects": "https://hydrus.com/api/vocab#dummyClass",
@@ -490,7 +490,7 @@ doc = {
                     "returnsHeader": []
                 },
                 {
-                    "@id": "https://hydrus.com/api/vocab#dummyclasses_update",
+                    "@id": "_:dummyclasses_update",
                     "@type": "http://schema.org/UpdateAction",
                     "description": "Update member of  dummyclasses ",
                     "expects": "https://hydrus.com/api/vocab#dummyClass",
@@ -509,7 +509,7 @@ doc = {
                     "returnsHeader": []
                 },
                 {
-                    "@id": "https://hydrus.com/api/vocab#dummyclasses_delete",
+                    "@id": "_:dummyclasses_delete",
                     "@type": "http://schema.org/DeleteAction",
                     "description": "Delete member of dummyclasses ",
                     "expects": "https://hydrus.com/api/vocab#dummyClass",
@@ -547,7 +547,7 @@ doc = {
             "description": "EntryPoint",
             "supportedOperation": [
                 {
-                    "@id": "https://hydrus.comentry_point",
+                    "@id": "_:entry_point",
                     "@type": "EntryPoint",
                     "description": "The APIs main entry point.",
                     "expects": "null",
@@ -705,7 +705,7 @@ doc = {
                         "range": "https://hydrus.com/api/vocab#:Extraclasses",
                         "supportedOperation": [
                             {
-                                "@id": "https://hydrus.com/api/vocab#extraclasses_retrieve",
+                                "@id": "_:extraclasses_retrieve",
                                 "@type": "http://schema.org/FindAction",
                                 "description": "Retrieves all the members of Extraclasses",
                                 "expects": "null",
@@ -716,7 +716,7 @@ doc = {
                                 "returnsHeader": []
                             },
                             {
-                                "@id": "https://hydrus.com/api/vocab#extraclasses_create",
+                                "@id": "_:extraclasses_create",
                                 "@type": "http://schema.org/AddAction",
                                 "description": "Create new member in Extraclasses",
                                 "expects": "https://hydrus.com/api/vocab#extraClass",
@@ -735,7 +735,7 @@ doc = {
                                 "returnsHeader": []
                             },
                             {
-                                "@id": "https://hydrus.com/api/vocab#extraclasses_update",
+                                "@id": "_:extraclasses_update",
                                 "@type": "http://schema.org/UpdateAction",
                                 "description": "Update member of  Extraclasses ",
                                 "expects": "https://hydrus.com/api/vocab#extraClass",
@@ -754,7 +754,7 @@ doc = {
                                 "returnsHeader": []
                             },
                             {
-                                "@id": "https://hydrus.com/api/vocab#extraclasses_delete",
+                                "@id": "_:extraclasses_delete",
                                 "@type": "http://schema.org/DeleteAction",
                                 "description": "Delete member of Extraclasses ",
                                 "expects": "https://hydrus.com/api/vocab#extraClass",
@@ -790,7 +790,7 @@ doc = {
                         "range": "https://hydrus.com/api/vocab#:dummyclasses",
                         "supportedOperation": [
                             {
-                                "@id": "https://hydrus.com/api/vocab#dummyclasses_retrieve",
+                                "@id": "_:dummyclasses_retrieve",
                                 "@type": "http://schema.org/FindAction",
                                 "description": "Retrieves all the members of dummyclasses",
                                 "expects": "null",
@@ -801,7 +801,7 @@ doc = {
                                 "returnsHeader": []
                             },
                             {
-                                "@id": "https://hydrus.com/api/vocab#dummyclasses_create",
+                                "@id": "_:dummyclasses_create",
                                 "@type": "http://schema.org/AddAction",
                                 "description": "Create new member in dummyclasses",
                                 "expects": "https://hydrus.com/api/vocab#dummyClass",
@@ -820,7 +820,7 @@ doc = {
                                 "returnsHeader": []
                             },
                             {
-                                "@id": "https://hydrus.com/api/vocab#dummyclasses_update",
+                                "@id": "_:dummyclasses_update",
                                 "@type": "http://schema.org/UpdateAction",
                                 "description": "Update member of  dummyclasses ",
                                 "expects": "https://hydrus.com/api/vocab#dummyClass",
@@ -839,7 +839,7 @@ doc = {
                                 "returnsHeader": []
                             },
                             {
-                                "@id": "https://hydrus.com/api/vocab#dummyclasses_delete",
+                                "@id": "_:dummyclasses_delete",
                                 "@type": "http://schema.org/DeleteAction",
                                 "description": "Delete member of dummyclasses ",
                                 "expects": "https://hydrus.com/api/vocab#dummyClass",

--- a/samples/doc_writer_sample_output.py
+++ b/samples/doc_writer_sample_output.py
@@ -55,13 +55,13 @@ doc = {
     "possibleStatus": [],
     "supportedClass": [
         {
-            "@id": "vocab:dummyClass",
+            "@id": "https://hydrus.com/api/dummyClass",
             "@type": "hydra:Class",
             "description": "A dummyClass for demo",
             "supportedOperation": [
                 {
                     "@type": "http://schema.org/UpdateAction",
-                    "expects": "vocab:dummyClass",
+                    "expects": "https://hydrus.com/api/dummyClass",
                     "expectsHeader": [],
                     "method": "POST",
                     "possibleStatus": [
@@ -100,7 +100,7 @@ doc = {
                 },
                 {
                     "@type": "http://schema.org/AddAction",
-                    "expects": "vocab:dummyClass",
+                    "expects": "https://hydrus.com/api/dummyClass",
                     "expectsHeader": [],
                     "method": "PUT",
                     "possibleStatus": [
@@ -130,7 +130,7 @@ doc = {
                             "title": ""
                         }
                     ],
-                    "returns": "vocab:dummyClass",
+                    "returns": "https://hydrus.com/api/dummyClass",
                     "returnsHeader": [],
                     "title": "GetClass"
                 }
@@ -156,7 +156,7 @@ doc = {
             "title": "dummyClass"
         },
         {
-            "@id": "vocab:extraClass",
+            "@id": "https://hydrus.com/api/extraClass",
             "@type": "hydra:Class",
             "description": "Class without any explicit methods",
             "supportedOperation": [],
@@ -164,13 +164,13 @@ doc = {
             "title": "extraClass"
         },
         {
-            "@id": "vocab:singleClass",
+            "@id": "https://hydrus.com/api/singleClass",
             "@type": "hydra:Class",
             "description": "A non collection class",
             "supportedOperation": [
                 {
                     "@type": "http://schema.org/UpdateAction",
-                    "expects": "vocab:singleClass",
+                    "expects": "https://hydrus.com/api/singleClass",
                     "expectsHeader": [],
                     "method": "POST",
                     "possibleStatus": [
@@ -206,7 +206,7 @@ doc = {
                 },
                 {
                     "@type": "http://schema.org/AddAction",
-                    "expects": "vocab:singleClass",
+                    "expects": "https://hydrus.com/api/singleClass",
                     "expectsHeader": [],
                     "method": "PUT",
                     "possibleStatus": [
@@ -236,7 +236,7 @@ doc = {
                             "title": ""
                         }
                     ],
-                    "returns": "vocab:singleClass",
+                    "returns": "https://hydrus.com/api/singleClass",
                     "returnsHeader": [],
                     "title": "GetClass"
                 }
@@ -264,8 +264,8 @@ doc = {
                         "@id": "vocab:singleClass/dummyProp",
                         "@type": "hydra:Link",
                         "description": "",
-                        "domain": "vocab:singleClass",
-                        "range": "vocab:dummyClass",
+                        "domain": "https://hydrus.com/api/singleClass",
+                        "range": "https://hydrus.com/api/dummyClass",
                         "supportedOperation": [],
                         "title": "dummyProp"
                     },
@@ -276,7 +276,7 @@ doc = {
                 },
                 {
                     "@type": "SupportedProperty",
-                    "property": "vocab:anotherSingleClass",
+                    "property": "https://hydrus.com/api/anotherSingleClass",
                     "readable": "false",
                     "required": "false",
                     "title": "singleClassProp",
@@ -286,7 +286,7 @@ doc = {
             "title": "singleClass"
         },
         {
-            "@id": "vocab:anotherSingleClass",
+            "@id": "https://hydrus.com/api/anotherSingleClass",
             "@type": "hydra:Class",
             "description": "An another non collection class",
             "supportedOperation": [
@@ -304,7 +304,7 @@ doc = {
                             "title": ""
                         }
                     ],
-                    "returns": "vocab:anotherSingleClass",
+                    "returns": "https://hydrus.com/api/anotherSingleClass",
                     "returnsHeader": [],
                     "title": "GetClass"
                 }
@@ -347,50 +347,50 @@ doc = {
             "title": "Collection"
         },
         {
-            "@id": "vocab:dummyClassCollection",
+            "@id": "https://hydrus.com/api/collection_1",
             "@type": "Collection",
-            "description": "A collection of dummyclass",
+            "description": "This collection comprises of instances of ExtraClass",
             "manages": {
-                "object": "vocab:dummyClass",
+                "object": "https://hydrus.com/api/extraClass",
                 "property": "rdf:type"
             },
             "subClassOf": "http://www.w3.org/ns/hydra/core#Collection",
             "supportedOperation": [
                 {
-                    "@id": "_:dummyclass_collection_retrieve",
+                    "@id": "https://hydrus.com/api/collection_1/Extraclasses_retrieve",
                     "@type": "http://schema.org/FindAction",
-                    "description": "Retrieves all dummyClass entities",
+                    "description": "Retrieves all the members of Extraclasses",
                     "expects": "null",
                     "expectsHeader": [],
                     "method": "GET",
                     "possibleStatus": [],
-                    "returns": "vocab:dummyClassCollection",
+                    "returns": "https://hydrus.com/api/extraClass",
                     "returnsHeader": []
                 },
                 {
-                    "@id": "_:dummyclass_create",
+                    "@id": "https://hydrus.com/api/collection_1/Extraclasses_create",
                     "@type": "http://schema.org/AddAction",
-                    "description": "Create new dummyClass entity",
-                    "expects": "vocab:dummyClass",
+                    "description": "Create new member in Extraclasses",
+                    "expects": "https://hydrus.com/api/extraClass",
                     "expectsHeader": [],
                     "method": "PUT",
                     "possibleStatus": [
                         {
                             "@context": "http://www.w3.org/ns/hydra/context.jsonld",
                             "@type": "Status",
-                            "description": "If the dummyClass entity was createdsuccessfully.",
+                            "description": "A new member in Extraclasses created",
                             "statusCode": 201,
                             "title": ""
                         }
                     ],
-                    "returns": "vocab:dummyClass",
+                    "returns": "https://hydrus.com/api/extraClass",
                     "returnsHeader": []
                 }
             ],
             "supportedProperty": [
                 {
                     "@type": "SupportedProperty",
-                    "description": "The dummyclass",
+                    "description": "The members of Extraclasses",
                     "property": "http://www.w3.org/ns/hydra/core#member",
                     "readable": "false",
                     "required": "false",
@@ -398,53 +398,53 @@ doc = {
                     "writeable": "false"
                 }
             ],
-            "title": "dummyClassCollection"
+            "title": "Extraclasses"
         },
         {
-            "@id": "vocab:extraClassCollection",
+            "@id": "https://hydrus.com/api/collection_2",
             "@type": "Collection",
-            "description": "A collection of extraclass",
+            "description": "This collection comprises of instances of dummyClass",
             "manages": {
-                "object": "vocab:extraClass",
+                "object": "https://hydrus.com/api/dummyClass",
                 "property": "rdf:type"
             },
             "subClassOf": "http://www.w3.org/ns/hydra/core#Collection",
             "supportedOperation": [
                 {
-                    "@id": "_:extraclass_collection_retrieve",
+                    "@id": "https://hydrus.com/api/collection_2/dummyclasses_retrieve",
                     "@type": "http://schema.org/FindAction",
-                    "description": "Retrieves all extraClass entities",
+                    "description": "Retrieves all the members of dummyclasses",
                     "expects": "null",
                     "expectsHeader": [],
                     "method": "GET",
                     "possibleStatus": [],
-                    "returns": "vocab:extraClassCollection",
+                    "returns": "https://hydrus.com/api/dummyClass",
                     "returnsHeader": []
                 },
                 {
-                    "@id": "_:extraclass_create",
+                    "@id": "https://hydrus.com/api/collection_2/dummyclasses_create",
                     "@type": "http://schema.org/AddAction",
-                    "description": "Create new extraClass entity",
-                    "expects": "vocab:extraClass",
+                    "description": "Create new member in dummyclasses",
+                    "expects": "https://hydrus.com/api/dummyClass",
                     "expectsHeader": [],
                     "method": "PUT",
                     "possibleStatus": [
                         {
                             "@context": "http://www.w3.org/ns/hydra/context.jsonld",
                             "@type": "Status",
-                            "description": "If the extraClass entity was createdsuccessfully.",
+                            "description": "A new member in dummyclasses created",
                             "statusCode": 201,
                             "title": ""
                         }
                     ],
-                    "returns": "vocab:extraClass",
+                    "returns": "https://hydrus.com/api/dummyClass",
                     "returnsHeader": []
                 }
             ],
             "supportedProperty": [
                 {
                     "@type": "SupportedProperty",
-                    "description": "The extraclass",
+                    "description": "The members of dummyclasses",
                     "property": "http://www.w3.org/ns/hydra/core#member",
                     "readable": "false",
                     "required": "false",
@@ -452,7 +452,7 @@ doc = {
                     "writeable": "false"
                 }
             ],
-            "title": "extraClassCollection"
+            "title": "dummyclasses"
         },
         {
             "@id": "vocab:EntryPoint",
@@ -487,7 +487,7 @@ doc = {
                                 "@id": "updateclass",
                                 "@type": "http://schema.org/UpdateAction",
                                 "description": "null",
-                                "expects": "vocab:singleClass",
+                                "expects": "https://hydrus.com/api/singleClass",
                                 "expectsHeader": [],
                                 "label": "UpdateClass",
                                 "method": "POST",
@@ -527,7 +527,7 @@ doc = {
                                 "@id": "addclass",
                                 "@type": "http://schema.org/AddAction",
                                 "description": "null",
-                                "expects": "vocab:singleClass",
+                                "expects": "https://hydrus.com/api/singleClass",
                                 "expectsHeader": [],
                                 "label": "AddClass",
                                 "method": "PUT",
@@ -560,7 +560,7 @@ doc = {
                                         "title": ""
                                     }
                                 ],
-                                "returns": "vocab:singleClass",
+                                "returns": "https://hydrus.com/api/singleClass",
                                 "returnsHeader": []
                             }
                         ]
@@ -597,7 +597,7 @@ doc = {
                                         "title": ""
                                     }
                                 ],
-                                "returns": "vocab:anotherSingleClass",
+                                "returns": "https://hydrus.com/api/anotherSingleClass",
                                 "returnsHeader": []
                             }
                         ]
@@ -607,91 +607,91 @@ doc = {
                     "writeable": "false"
                 },
                 {
-                    "hydra:description": "The dummyClassCollection collection",
-                    "hydra:title": "dummyclasscollection",
-                    "property": {
-                        "@id": "vocab:EntryPoint/DcTest",
-                        "@type": "hydra:Link",
-                        "description": "The dummyClassCollection collection",
-                        "domain": "vocab:EntryPoint",
-                        "label": "dummyClassCollection",
-                        "range": "vocab:dummyClassCollection",
-                        "supportedOperation": [
-                            {
-                                "@id": "_:dummyclass_collection_retrieve",
-                                "@type": "http://schema.org/FindAction",
-                                "description": "Retrieves all dummyClass entities",
-                                "expects": "null",
-                                "expectsHeader": [],
-                                "method": "GET",
-                                "possibleStatus": [],
-                                "returns": "vocab:dummyClassCollection",
-                                "returnsHeader": []
-                            },
-                            {
-                                "@id": "_:dummyclass_create",
-                                "@type": "http://schema.org/AddAction",
-                                "description": "Create new dummyClass entity",
-                                "expects": "vocab:dummyClass",
-                                "expectsHeader": [],
-                                "method": "PUT",
-                                "possibleStatus": [
-                                    {
-                                        "@context": "http://www.w3.org/ns/hydra/context.jsonld",
-                                        "@type": "Status",
-                                        "description": "If the dummyClass entity was createdsuccessfully.",
-                                        "statusCode": 201,
-                                        "title": ""
-                                    }
-                                ],
-                                "returns": "vocab:dummyClass",
-                                "returnsHeader": []
-                            }
-                        ]
-                    },
-                    "readable": "true",
-                    "required": "null",
-                    "writeable": "false"
-                },
-                {
-                    "hydra:description": "The extraClassCollection collection",
-                    "hydra:title": "extraclasscollection",
+                    "hydra:description": "The Extraclasses collection",
+                    "hydra:title": "extraclasses",
                     "property": {
                         "@id": "vocab:EntryPoint/EcTest",
                         "@type": "hydra:Link",
-                        "description": "The extraClassCollection collection",
+                        "description": "The Extraclasses collection",
                         "domain": "vocab:EntryPoint",
-                        "label": "extraClassCollection",
-                        "range": "vocab:extraClassCollection",
+                        "label": "Extraclasses",
+                        "range": "vocab:Extraclasses",
                         "supportedOperation": [
                             {
-                                "@id": "_:extraclass_collection_retrieve",
+                                "@id": "https://hydrus.com/api/collection_1/extraclasses_retrieve",
                                 "@type": "http://schema.org/FindAction",
-                                "description": "Retrieves all extraClass entities",
+                                "description": "Retrieves all the members of Extraclasses",
                                 "expects": "null",
                                 "expectsHeader": [],
                                 "method": "GET",
                                 "possibleStatus": [],
-                                "returns": "vocab:extraClassCollection",
+                                "returns": "https://hydrus.com/api/extraClass",
                                 "returnsHeader": []
                             },
                             {
-                                "@id": "_:extraclass_create",
+                                "@id": "https://hydrus.com/api/collection_1/extraclasses_create",
                                 "@type": "http://schema.org/AddAction",
-                                "description": "Create new extraClass entity",
-                                "expects": "vocab:extraClass",
+                                "description": "Create new member in Extraclasses",
+                                "expects": "https://hydrus.com/api/extraClass",
                                 "expectsHeader": [],
                                 "method": "PUT",
                                 "possibleStatus": [
                                     {
                                         "@context": "http://www.w3.org/ns/hydra/context.jsonld",
                                         "@type": "Status",
-                                        "description": "If the extraClass entity was createdsuccessfully.",
+                                        "description": "A new member in Extraclasses created",
                                         "statusCode": 201,
                                         "title": ""
                                     }
                                 ],
-                                "returns": "vocab:extraClass",
+                                "returns": "https://hydrus.com/api/extraClass",
+                                "returnsHeader": []
+                            }
+                        ]
+                    },
+                    "readable": "true",
+                    "required": "null",
+                    "writeable": "false"
+                },
+                {
+                    "hydra:description": "The dummyclasses collection",
+                    "hydra:title": "dummyclasses",
+                    "property": {
+                        "@id": "vocab:EntryPoint/DcTest",
+                        "@type": "hydra:Link",
+                        "description": "The dummyclasses collection",
+                        "domain": "vocab:EntryPoint",
+                        "label": "dummyclasses",
+                        "range": "vocab:dummyclasses",
+                        "supportedOperation": [
+                            {
+                                "@id": "https://hydrus.com/api/collection_2/dummyclasses_retrieve",
+                                "@type": "http://schema.org/FindAction",
+                                "description": "Retrieves all the members of dummyclasses",
+                                "expects": "null",
+                                "expectsHeader": [],
+                                "method": "GET",
+                                "possibleStatus": [],
+                                "returns": "https://hydrus.com/api/dummyClass",
+                                "returnsHeader": []
+                            },
+                            {
+                                "@id": "https://hydrus.com/api/collection_2/dummyclasses_create",
+                                "@type": "http://schema.org/AddAction",
+                                "description": "Create new member in dummyclasses",
+                                "expects": "https://hydrus.com/api/dummyClass",
+                                "expectsHeader": [],
+                                "method": "PUT",
+                                "possibleStatus": [
+                                    {
+                                        "@context": "http://www.w3.org/ns/hydra/context.jsonld",
+                                        "@type": "Status",
+                                        "description": "A new member in dummyclasses created",
+                                        "statusCode": 201,
+                                        "title": ""
+                                    }
+                                ],
+                                "returns": "https://hydrus.com/api/dummyClass",
                                 "returnsHeader": []
                             }
                         ]

--- a/samples/doc_writer_sample_output.py
+++ b/samples/doc_writer_sample_output.py
@@ -8,6 +8,10 @@ doc = {
             "@id": "rdfs:domain",
             "@type": "@id"
         },
+        "entrypoint": {
+            "@id": "hydra:entrypoint",
+            "@type": "@id"
+        },
         "expects": {
             "@id": "hydra:expects",
             "@type": "@id"
@@ -17,6 +21,10 @@ doc = {
         "label": "rdfs:label",
         "manages": "hydra:manages",
         "method": "hydra:method",
+        "object": {
+            "@id": "hydra:object",
+            "@type": "@id"
+        },
         "possibleStatus": "hydra:possibleStatus",
         "property": {
             "@id": "hydra:property",
@@ -39,6 +47,10 @@ doc = {
         "statusCode": "hydra:statusCode",
         "subClassOf": {
             "@id": "rdfs:subClassOf",
+            "@type": "@id"
+        },
+        "subject": {
+            "@id": "hydra:subject",
             "@type": "@id"
         },
         "supportedClass": "hydra:supportedClass",

--- a/samples/doc_writer_sample_output.py
+++ b/samples/doc_writer_sample_output.py
@@ -57,7 +57,6 @@ doc = {
         "supportedOperation": "hydra:supportedOperation",
         "supportedProperty": "hydra:supportedProperty",
         "title": "hydra:title",
-        "vocab": "https://hydrus.com/api/vocab#",
         "writeable": "hydra:writeable"
     },
     "@id": "https://hydrus.com/api/vocab",
@@ -67,13 +66,13 @@ doc = {
     "possibleStatus": [],
     "supportedClass": [
         {
-            "@id": "https://hydrus.com/api/dummyClass",
+            "@id": "https://hydrus.com/api/vocab#dummyClass",
             "@type": "hydra:Class",
             "description": "A dummyClass for demo",
             "supportedOperation": [
                 {
                     "@type": "http://schema.org/UpdateAction",
-                    "expects": "https://hydrus.com/api/dummyClass",
+                    "expects": "https://hydrus.com/api/vocab#dummyClass",
                     "expectsHeader": [],
                     "method": "POST",
                     "possibleStatus": [
@@ -112,7 +111,7 @@ doc = {
                 },
                 {
                     "@type": "http://schema.org/AddAction",
-                    "expects": "https://hydrus.com/api/dummyClass",
+                    "expects": "https://hydrus.com/api/vocab#dummyClass",
                     "expectsHeader": [],
                     "method": "PUT",
                     "possibleStatus": [
@@ -142,7 +141,7 @@ doc = {
                             "title": ""
                         }
                     ],
-                    "returns": "https://hydrus.com/api/dummyClass",
+                    "returns": "https://hydrus.com/api/vocab#dummyClass",
                     "returnsHeader": [],
                     "title": "GetClass"
                 }
@@ -168,7 +167,7 @@ doc = {
             "title": "dummyClass"
         },
         {
-            "@id": "https://hydrus.com/api/extraClass",
+            "@id": "https://hydrus.com/api/vocab#extraClass",
             "@type": "hydra:Class",
             "description": "Class without any explicit methods",
             "supportedOperation": [],
@@ -176,13 +175,13 @@ doc = {
             "title": "extraClass"
         },
         {
-            "@id": "https://hydrus.com/api/singleClass",
+            "@id": "https://hydrus.com/api/vocab#singleClass",
             "@type": "hydra:Class",
             "description": "A non collection class",
             "supportedOperation": [
                 {
                     "@type": "http://schema.org/UpdateAction",
-                    "expects": "https://hydrus.com/api/singleClass",
+                    "expects": "https://hydrus.com/api/vocab#singleClass",
                     "expectsHeader": [],
                     "method": "POST",
                     "possibleStatus": [
@@ -218,7 +217,7 @@ doc = {
                 },
                 {
                     "@type": "http://schema.org/AddAction",
-                    "expects": "https://hydrus.com/api/singleClass",
+                    "expects": "https://hydrus.com/api/vocab#singleClass",
                     "expectsHeader": [],
                     "method": "PUT",
                     "possibleStatus": [
@@ -248,7 +247,7 @@ doc = {
                             "title": ""
                         }
                     ],
-                    "returns": "https://hydrus.com/api/singleClass",
+                    "returns": "https://hydrus.com/api/vocab#singleClass",
                     "returnsHeader": [],
                     "title": "GetClass"
                 }
@@ -273,11 +272,11 @@ doc = {
                 {
                     "@type": "SupportedProperty",
                     "property": {
-                        "@id": "vocab:singleClass/dummyProp",
+                        "@id": "https://hydrus.com/api/vocab#singleClass/dummyProp",
                         "@type": "hydra:Link",
                         "description": "",
-                        "domain": "https://hydrus.com/api/singleClass",
-                        "range": "https://hydrus.com/api/dummyClass",
+                        "domain": "https://hydrus.com/api/vocab#singleClass",
+                        "range": "https://hydrus.com/api/vocab#dummyClass",
                         "supportedOperation": [],
                         "title": "dummyProp"
                     },
@@ -288,7 +287,7 @@ doc = {
                 },
                 {
                     "@type": "SupportedProperty",
-                    "property": "https://hydrus.com/api/anotherSingleClass",
+                    "property": "https://hydrus.com/api/vocab#anotherSingleClass",
                     "readable": "false",
                     "required": "false",
                     "title": "singleClassProp",
@@ -298,7 +297,7 @@ doc = {
             "title": "singleClass"
         },
         {
-            "@id": "https://hydrus.com/api/anotherSingleClass",
+            "@id": "https://hydrus.com/api/vocab#anotherSingleClass",
             "@type": "hydra:Class",
             "description": "An another non collection class",
             "supportedOperation": [
@@ -316,7 +315,7 @@ doc = {
                             "title": ""
                         }
                     ],
-                    "returns": "https://hydrus.com/api/anotherSingleClass",
+                    "returns": "https://hydrus.com/api/vocab#anotherSingleClass",
                     "returnsHeader": [],
                     "title": "GetClass"
                 }
@@ -334,17 +333,17 @@ doc = {
             "title": "anotherSingleClass"
         },
         {
-            "@id": "http://www.w3.org/ns/hydra/core#Resource",
+            "@id": "https://hydrus.com/api/vocab#http://www.w3.org/ns/hydra/core#Resource",
             "@type": "hydra:Class",
-            "description": "null",
+            "description": "Resource",
             "supportedOperation": [],
             "supportedProperty": [],
-            "title": "Resource"
+            "title": "http://www.w3.org/ns/hydra/core#Resource"
         },
         {
-            "@id": "http://www.w3.org/ns/hydra/core#Collection",
+            "@id": "https://hydrus.com/api/vocab#http://www.w3.org/ns/hydra/core#Collection",
             "@type": "hydra:Class",
-            "description": "null",
+            "description": "Collection",
             "supportedOperation": [],
             "supportedProperty": [
                 {
@@ -356,34 +355,34 @@ doc = {
                     "writeable": "false"
                 }
             ],
-            "title": "Collection"
+            "title": "http://www.w3.org/ns/hydra/core#Collection"
         },
         {
-            "@id": "https://hydrus.com/api/collection_1",
+            "@id": "https://hydrus.com/api/vocab#Extraclasses",
             "@type": "Collection",
             "description": "This collection comprises of instances of ExtraClass",
             "manages": {
-                "object": "https://hydrus.com/api/extraClass",
+                "object": "https://hydrus.com/api/vocab#extraClass",
                 "property": "rdf:type"
             },
             "subClassOf": "http://www.w3.org/ns/hydra/core#Collection",
             "supportedOperation": [
                 {
-                    "@id": "https://hydrus.com/api/collection_1/Extraclasses_retrieve",
+                    "@id": "https://hydrus.com/api/vocab#Extraclasses_retrieve",
                     "@type": "http://schema.org/FindAction",
                     "description": "Retrieves all the members of Extraclasses",
                     "expects": "null",
                     "expectsHeader": [],
                     "method": "GET",
                     "possibleStatus": [],
-                    "returns": "https://hydrus.com/api/extraClass",
+                    "returns": "https://hydrus.com/api/vocab#extraClass",
                     "returnsHeader": []
                 },
                 {
-                    "@id": "https://hydrus.com/api/collection_1/Extraclasses_create",
+                    "@id": "https://hydrus.com/api/vocab#Extraclasses_create",
                     "@type": "http://schema.org/AddAction",
                     "description": "Create new member in Extraclasses",
-                    "expects": "https://hydrus.com/api/extraClass",
+                    "expects": "https://hydrus.com/api/vocab#extraClass",
                     "expectsHeader": [],
                     "method": "PUT",
                     "possibleStatus": [
@@ -395,7 +394,45 @@ doc = {
                             "title": ""
                         }
                     ],
-                    "returns": "https://hydrus.com/api/extraClass",
+                    "returns": "https://hydrus.com/api/vocab#extraClass",
+                    "returnsHeader": []
+                },
+                {
+                    "@id": "https://hydrus.com/api/vocab#Extraclasses_update",
+                    "@type": "http://schema.org/UpdateAction",
+                    "description": "Update member of  Extraclasses ",
+                    "expects": "https://hydrus.com/api/vocab#extraClass",
+                    "expectsHeader": [],
+                    "method": "POST",
+                    "possibleStatus": [
+                        {
+                            "@context": "http://www.w3.org/ns/hydra/context.jsonld",
+                            "@type": "Status",
+                            "description": "If the entity was updatedfrom Extraclasses.",
+                            "statusCode": 200,
+                            "title": ""
+                        }
+                    ],
+                    "returns": "https://hydrus.com/api/vocab#extraClass",
+                    "returnsHeader": []
+                },
+                {
+                    "@id": "https://hydrus.com/api/vocab#Extraclasses_delete",
+                    "@type": "http://schema.org/DeleteAction",
+                    "description": "Delete member of Extraclasses ",
+                    "expects": "https://hydrus.com/api/vocab#extraClass",
+                    "expectsHeader": [],
+                    "method": "DELETE",
+                    "possibleStatus": [
+                        {
+                            "@context": "http://www.w3.org/ns/hydra/context.jsonld",
+                            "@type": "Status",
+                            "description": "If entity was deletedsuccessfully from Extraclasses.",
+                            "statusCode": 200,
+                            "title": ""
+                        }
+                    ],
+                    "returns": "https://hydrus.com/api/vocab#extraClass",
                     "returnsHeader": []
                 }
             ],
@@ -413,31 +450,31 @@ doc = {
             "title": "Extraclasses"
         },
         {
-            "@id": "https://hydrus.com/api/collection_2",
+            "@id": "https://hydrus.com/api/vocab#dummyclasses",
             "@type": "Collection",
             "description": "This collection comprises of instances of dummyClass",
             "manages": {
-                "object": "https://hydrus.com/api/dummyClass",
+                "object": "https://hydrus.com/api/vocab#dummyClass",
                 "property": "rdf:type"
             },
             "subClassOf": "http://www.w3.org/ns/hydra/core#Collection",
             "supportedOperation": [
                 {
-                    "@id": "https://hydrus.com/api/collection_2/dummyclasses_retrieve",
+                    "@id": "https://hydrus.com/api/vocab#dummyclasses_retrieve",
                     "@type": "http://schema.org/FindAction",
                     "description": "Retrieves all the members of dummyclasses",
                     "expects": "null",
                     "expectsHeader": [],
                     "method": "GET",
                     "possibleStatus": [],
-                    "returns": "https://hydrus.com/api/dummyClass",
+                    "returns": "https://hydrus.com/api/vocab#dummyClass",
                     "returnsHeader": []
                 },
                 {
-                    "@id": "https://hydrus.com/api/collection_2/dummyclasses_create",
+                    "@id": "https://hydrus.com/api/vocab#dummyclasses_create",
                     "@type": "http://schema.org/AddAction",
                     "description": "Create new member in dummyclasses",
-                    "expects": "https://hydrus.com/api/dummyClass",
+                    "expects": "https://hydrus.com/api/vocab#dummyClass",
                     "expectsHeader": [],
                     "method": "PUT",
                     "possibleStatus": [
@@ -449,7 +486,45 @@ doc = {
                             "title": ""
                         }
                     ],
-                    "returns": "https://hydrus.com/api/dummyClass",
+                    "returns": "https://hydrus.com/api/vocab#dummyClass",
+                    "returnsHeader": []
+                },
+                {
+                    "@id": "https://hydrus.com/api/vocab#dummyclasses_update",
+                    "@type": "http://schema.org/UpdateAction",
+                    "description": "Update member of  dummyclasses ",
+                    "expects": "https://hydrus.com/api/vocab#dummyClass",
+                    "expectsHeader": [],
+                    "method": "POST",
+                    "possibleStatus": [
+                        {
+                            "@context": "http://www.w3.org/ns/hydra/context.jsonld",
+                            "@type": "Status",
+                            "description": "If the entity was updatedfrom dummyclasses.",
+                            "statusCode": 200,
+                            "title": ""
+                        }
+                    ],
+                    "returns": "https://hydrus.com/api/vocab#dummyClass",
+                    "returnsHeader": []
+                },
+                {
+                    "@id": "https://hydrus.com/api/vocab#dummyclasses_delete",
+                    "@type": "http://schema.org/DeleteAction",
+                    "description": "Delete member of dummyclasses ",
+                    "expects": "https://hydrus.com/api/vocab#dummyClass",
+                    "expectsHeader": [],
+                    "method": "DELETE",
+                    "possibleStatus": [
+                        {
+                            "@context": "http://www.w3.org/ns/hydra/context.jsonld",
+                            "@type": "Status",
+                            "description": "If entity was deletedsuccessfully from dummyclasses.",
+                            "statusCode": 200,
+                            "title": ""
+                        }
+                    ],
+                    "returns": "https://hydrus.com/api/vocab#dummyClass",
                     "returnsHeader": []
                 }
             ],
@@ -467,13 +542,13 @@ doc = {
             "title": "dummyclasses"
         },
         {
-            "@id": "vocab:EntryPoint",
+            "@id": "EntryPoint",
             "@type": "hydra:Class",
-            "description": "The main entry point or homepage of the API.",
+            "description": "EntryPoint",
             "supportedOperation": [
                 {
-                    "@id": "_:entry_point",
-                    "@type": "vocab:EntryPoint",
+                    "@id": "https://hydrus.comentry_point",
+                    "@type": "EntryPoint",
                     "description": "The APIs main entry point.",
                     "expects": "null",
                     "expectsHeader": [],
@@ -488,18 +563,18 @@ doc = {
                     "hydra:description": "The singleClass Class",
                     "hydra:title": "singleclass",
                     "property": {
-                        "@id": "vocab:EntryPoint/singleClass",
+                        "@id": "https://hydrus.com/api/vocab#EntryPoint/singleClass",
                         "@type": "hydra:Link",
                         "description": "A non collection class",
-                        "domain": "vocab:EntryPoint",
+                        "domain": "https://hydrus.com/api/vocab#EntryPoint",
                         "label": "singleClass",
-                        "range": "vocab:singleClass",
+                        "range": "https://hydrus.com/api/vocab#singleClass",
                         "supportedOperation": [
                             {
                                 "@id": "updateclass",
                                 "@type": "http://schema.org/UpdateAction",
                                 "description": "null",
-                                "expects": "https://hydrus.com/api/singleClass",
+                                "expects": "https://hydrus.com/api/vocab#singleClass",
                                 "expectsHeader": [],
                                 "label": "UpdateClass",
                                 "method": "POST",
@@ -539,7 +614,7 @@ doc = {
                                 "@id": "addclass",
                                 "@type": "http://schema.org/AddAction",
                                 "description": "null",
-                                "expects": "https://hydrus.com/api/singleClass",
+                                "expects": "https://hydrus.com/api/vocab#singleClass",
                                 "expectsHeader": [],
                                 "label": "AddClass",
                                 "method": "PUT",
@@ -572,7 +647,7 @@ doc = {
                                         "title": ""
                                     }
                                 ],
-                                "returns": "https://hydrus.com/api/singleClass",
+                                "returns": "https://hydrus.com/api/vocab#singleClass",
                                 "returnsHeader": []
                             }
                         ]
@@ -585,12 +660,12 @@ doc = {
                     "hydra:description": "The anotherSingleClass Class",
                     "hydra:title": "anothersingleclass",
                     "property": {
-                        "@id": "vocab:EntryPoint/anotherSingleClass",
+                        "@id": "https://hydrus.com/api/vocab#EntryPoint/anotherSingleClass",
                         "@type": "hydra:Link",
                         "description": "An another non collection class",
-                        "domain": "vocab:EntryPoint",
+                        "domain": "https://hydrus.com/api/vocab#EntryPoint",
                         "label": "anotherSingleClass",
-                        "range": "vocab:anotherSingleClass",
+                        "range": "https://hydrus.com/api/vocab#anotherSingleClass",
                         "supportedOperation": [
                             {
                                 "@id": "getclass",
@@ -609,7 +684,7 @@ doc = {
                                         "title": ""
                                     }
                                 ],
-                                "returns": "https://hydrus.com/api/anotherSingleClass",
+                                "returns": "https://hydrus.com/api/vocab#anotherSingleClass",
                                 "returnsHeader": []
                             }
                         ]
@@ -622,29 +697,29 @@ doc = {
                     "hydra:description": "The Extraclasses collection",
                     "hydra:title": "extraclasses",
                     "property": {
-                        "@id": "vocab:EntryPoint/EcTest",
+                        "@id": "https://hydrus.com/api/vocab#EntryPoint/EcTest",
                         "@type": "hydra:Link",
                         "description": "The Extraclasses collection",
-                        "domain": "vocab:EntryPoint",
+                        "domain": "https://hydrus.com/api/vocab#EntryPoint",
                         "label": "Extraclasses",
-                        "range": "vocab:Extraclasses",
+                        "range": "https://hydrus.com/api/vocab#:Extraclasses",
                         "supportedOperation": [
                             {
-                                "@id": "https://hydrus.com/api/collection_1/extraclasses_retrieve",
+                                "@id": "https://hydrus.com/api/vocab#extraclasses_retrieve",
                                 "@type": "http://schema.org/FindAction",
                                 "description": "Retrieves all the members of Extraclasses",
                                 "expects": "null",
                                 "expectsHeader": [],
                                 "method": "GET",
                                 "possibleStatus": [],
-                                "returns": "https://hydrus.com/api/extraClass",
+                                "returns": "https://hydrus.com/api/vocab#extraClass",
                                 "returnsHeader": []
                             },
                             {
-                                "@id": "https://hydrus.com/api/collection_1/extraclasses_create",
+                                "@id": "https://hydrus.com/api/vocab#extraclasses_create",
                                 "@type": "http://schema.org/AddAction",
                                 "description": "Create new member in Extraclasses",
-                                "expects": "https://hydrus.com/api/extraClass",
+                                "expects": "https://hydrus.com/api/vocab#extraClass",
                                 "expectsHeader": [],
                                 "method": "PUT",
                                 "possibleStatus": [
@@ -656,7 +731,45 @@ doc = {
                                         "title": ""
                                     }
                                 ],
-                                "returns": "https://hydrus.com/api/extraClass",
+                                "returns": "https://hydrus.com/api/vocab#extraClass",
+                                "returnsHeader": []
+                            },
+                            {
+                                "@id": "https://hydrus.com/api/vocab#extraclasses_update",
+                                "@type": "http://schema.org/UpdateAction",
+                                "description": "Update member of  Extraclasses ",
+                                "expects": "https://hydrus.com/api/vocab#extraClass",
+                                "expectsHeader": [],
+                                "method": "POST",
+                                "possibleStatus": [
+                                    {
+                                        "@context": "http://www.w3.org/ns/hydra/context.jsonld",
+                                        "@type": "Status",
+                                        "description": "If the entity was updatedfrom Extraclasses.",
+                                        "statusCode": 200,
+                                        "title": ""
+                                    }
+                                ],
+                                "returns": "https://hydrus.com/api/vocab#extraClass",
+                                "returnsHeader": []
+                            },
+                            {
+                                "@id": "https://hydrus.com/api/vocab#extraclasses_delete",
+                                "@type": "http://schema.org/DeleteAction",
+                                "description": "Delete member of Extraclasses ",
+                                "expects": "https://hydrus.com/api/vocab#extraClass",
+                                "expectsHeader": [],
+                                "method": "DELETE",
+                                "possibleStatus": [
+                                    {
+                                        "@context": "http://www.w3.org/ns/hydra/context.jsonld",
+                                        "@type": "Status",
+                                        "description": "If entity was deletedsuccessfully from Extraclasses.",
+                                        "statusCode": 200,
+                                        "title": ""
+                                    }
+                                ],
+                                "returns": "https://hydrus.com/api/vocab#extraClass",
                                 "returnsHeader": []
                             }
                         ]
@@ -669,29 +782,29 @@ doc = {
                     "hydra:description": "The dummyclasses collection",
                     "hydra:title": "dummyclasses",
                     "property": {
-                        "@id": "vocab:EntryPoint/DcTest",
+                        "@id": "https://hydrus.com/api/vocab#EntryPoint/DcTest",
                         "@type": "hydra:Link",
                         "description": "The dummyclasses collection",
-                        "domain": "vocab:EntryPoint",
+                        "domain": "https://hydrus.com/api/vocab#EntryPoint",
                         "label": "dummyclasses",
-                        "range": "vocab:dummyclasses",
+                        "range": "https://hydrus.com/api/vocab#:dummyclasses",
                         "supportedOperation": [
                             {
-                                "@id": "https://hydrus.com/api/collection_2/dummyclasses_retrieve",
+                                "@id": "https://hydrus.com/api/vocab#dummyclasses_retrieve",
                                 "@type": "http://schema.org/FindAction",
                                 "description": "Retrieves all the members of dummyclasses",
                                 "expects": "null",
                                 "expectsHeader": [],
                                 "method": "GET",
                                 "possibleStatus": [],
-                                "returns": "https://hydrus.com/api/dummyClass",
+                                "returns": "https://hydrus.com/api/vocab#dummyClass",
                                 "returnsHeader": []
                             },
                             {
-                                "@id": "https://hydrus.com/api/collection_2/dummyclasses_create",
+                                "@id": "https://hydrus.com/api/vocab#dummyclasses_create",
                                 "@type": "http://schema.org/AddAction",
                                 "description": "Create new member in dummyclasses",
-                                "expects": "https://hydrus.com/api/dummyClass",
+                                "expects": "https://hydrus.com/api/vocab#dummyClass",
                                 "expectsHeader": [],
                                 "method": "PUT",
                                 "possibleStatus": [
@@ -703,7 +816,45 @@ doc = {
                                         "title": ""
                                     }
                                 ],
-                                "returns": "https://hydrus.com/api/dummyClass",
+                                "returns": "https://hydrus.com/api/vocab#dummyClass",
+                                "returnsHeader": []
+                            },
+                            {
+                                "@id": "https://hydrus.com/api/vocab#dummyclasses_update",
+                                "@type": "http://schema.org/UpdateAction",
+                                "description": "Update member of  dummyclasses ",
+                                "expects": "https://hydrus.com/api/vocab#dummyClass",
+                                "expectsHeader": [],
+                                "method": "POST",
+                                "possibleStatus": [
+                                    {
+                                        "@context": "http://www.w3.org/ns/hydra/context.jsonld",
+                                        "@type": "Status",
+                                        "description": "If the entity was updatedfrom dummyclasses.",
+                                        "statusCode": 200,
+                                        "title": ""
+                                    }
+                                ],
+                                "returns": "https://hydrus.com/api/vocab#dummyClass",
+                                "returnsHeader": []
+                            },
+                            {
+                                "@id": "https://hydrus.com/api/vocab#dummyclasses_delete",
+                                "@type": "http://schema.org/DeleteAction",
+                                "description": "Delete member of dummyclasses ",
+                                "expects": "https://hydrus.com/api/vocab#dummyClass",
+                                "expectsHeader": [],
+                                "method": "DELETE",
+                                "possibleStatus": [
+                                    {
+                                        "@context": "http://www.w3.org/ns/hydra/context.jsonld",
+                                        "@type": "Status",
+                                        "description": "If entity was deletedsuccessfully from dummyclasses.",
+                                        "statusCode": 200,
+                                        "title": ""
+                                    }
+                                ],
+                                "returns": "https://hydrus.com/api/vocab#dummyClass",
                                 "returnsHeader": []
                             }
                         ]


### PR DESCRIPTION
<!-- Please create/claim an issue before sending a PR -->
<!-- Add issue number (Eg: fixes #123) -->

Fixes #44 

### Checklist
- [x] My branch is up-to-date with upstream/develop branch.
- [x] Everything works and tested for Python 3.5.2 and above.

### Description
<!-- Describe about what this PR does, previous state and new state of the output -->
This PR removes the dependency of collections on classes. Earlier, one had to use `add_supported_class(classname, collection=True)`
Now the writers have flexibility to tweak collections as per their preferences. They can create collections and then add to HydraDoc via ` apidoc.add_supported_collection(collection_name)`
In other words, now there is no forced dependency of classes on collection

### Change logs

<!-- #### Added -->
<!-- Edit these points below to describe the new features added with this PR -->
<!-- - Feature 1 -->
<!-- - Feature 2 -->
- in the doc_writer_sample.py, passed full URI instead of passing one word URIs
- added method to add collections to Hydradoc
- some compact URIs were not expanding when used expansion algorithm was used, for eg: `_:singleclass_retrieve`. Replaced them with proper URIs.


<!-- #### Changed -->
<!-- Edit these points below to describe the changes made in existing functionality with this PR -->
<!-- - Change 1 -->
<!-- - Change 1 -->


<!-- #### Fixed -->
<!-- Edit these points below to describe the bug fixes made with this PR -->
<!-- - Bug 1 -->


<!-- #### Removed -->
<!-- Edit these points below to describe the removed features with this PR -->
<!-- - Deprecated feature 1 -->
