### PR TITLE
Add support for POST and DELETE on collection classes

### DIFF
--- a/hydra_python_core/doc_writer.py
+++ b/hydra_python_core/doc_writer.py
@@ -272,7 +272,7 @@ class HydraCollection():
         self.supportedOperation = list()  # type: List
         self.supportedProperty = [HydraClassProp("http://www.w3.org/ns/hydra/core#member",
                                                  "members",
-                                                 False, False, False,
+                                                 True, True, False,
                                                  "The {}".format(self.class_.title.lower()))]
         if manages is None:
             # provide default manages block

--- a/hydra_python_core/doc_writer.py
+++ b/hydra_python_core/doc_writer.py
@@ -293,8 +293,8 @@ class HydraCollection():
 
         if put:
             put_op = HydraCollectionOp("_:{}_create".format(self.class_.title.lower()),
-                                        "http://schema.org/AddAction",
-                                        "PUT", "Create new {} entity".format(
+                                       "http://schema.org/AddAction",
+                                       "PUT", "Create new {} entity".format(
                 self.class_.title),
                 self.class_.id_, self.class_.id_, [], [],
                 [HydraStatus(code=201, desc="If the {} entity was created"
@@ -315,8 +315,8 @@ class HydraCollection():
 
         if delete:
             delete_op = HydraCollectionOp("_:{}_delete".format(self.class_.title.lower()),
-                                        "http://schema.org/DeleteAction",
-                                        "DELETE", "Delete existing {} entity".format(
+                                          "http://schema.org/DeleteAction",
+                                          "DELETE", "Delete existing {} entity".format(
                 self.class_.title),
                 self.class_.id_, self.class_.id_, [], [],
                 [HydraStatus(code=200, desc="If the {} entity was deleted"

--- a/hydra_python_core/doc_writer.py
+++ b/hydra_python_core/doc_writer.py
@@ -25,7 +25,8 @@ class HydraDoc():
     def add_supported_class(
             self, class_: 'HydraClass', collection: Union[bool, 'HydraCollection']=False,
             collection_name: str=None,
-            collection_path: str=None, collectionGet: bool=True, collectionPost: bool=True,
+            collection_path: str=None, collectionGet: bool=True, collectionPut: bool=True,
+            collectionPost: bool=True, collectionDelete: bool=True,
             collection_manages: Union[Dict[str, Any], List]=None) -> None:
         """Add a new supportedClass.
 
@@ -44,7 +45,7 @@ class HydraDoc():
         if collection:
             collection = HydraCollection(
                 class_, collection_name, collection_path, collection_manages, collectionGet,
-                collectionPost)
+                collectionPut, collectionPost, collectionDelete)
             self.collections[collection.path] = {
                 "context": Context(address="{}{}".format(self.base_url, self.API),
                                    collection=collection), "collection": collection}
@@ -262,7 +263,7 @@ class HydraCollection():
             collection_name: str=None,
             collection_path: str=None,
             manages: Union[Dict[str, Any], List]=None,
-            get: bool=True, post: bool=True) -> None:
+            get: bool=True, put: bool=True, post: bool=True, delete: bool=True) -> None:
         """Generate Collection for a given class."""
         self.class_ = class_
         self.name = "{}Collection".format(class_.title) \
@@ -290,13 +291,35 @@ class HydraCollection():
                 None, "vocab:{}".format(self.name), [], [], [])
             self.supportedOperation.append(get_op)
 
-        if post:
-            post_op = HydraCollectionOp("_:{}_create".format(self.class_.title.lower()),
+        if put:
+            put_op = HydraCollectionOp("_:{}_create".format(self.class_.title.lower()),
                                         "http://schema.org/AddAction",
                                         "PUT", "Create new {} entity".format(
                 self.class_.title),
                 self.class_.id_, self.class_.id_, [], [],
                 [HydraStatus(code=201, desc="If the {} entity was created"
+                             "successfully.".format(self.class_.title))]
+            )
+            self.supportedOperation.append(put_op)
+
+        if post:
+            post_op = HydraCollectionOp("_:{}_update".format(self.class_.title.lower()),
+                                        "http://schema.org/UpdateAction",
+                                        "POST", "Update existing {} entity".format(
+                self.class_.title),
+                self.class_.id_, self.class_.id_, [], [],
+                [HydraStatus(code=200, desc="If the {} entity was updated"
+                             "successfully.".format(self.class_.title))]
+            )
+            self.supportedOperation.append(post_op)
+
+        if delete:
+            delete_op = HydraCollectionOp("_:{}_delete".format(self.class_.title.lower()),
+                                        "http://schema.org/DeleteAction",
+                                        "DELETE", "Delete existing {} entity".format(
+                self.class_.title),
+                self.class_.id_, self.class_.id_, [], [],
+                [HydraStatus(code=200, desc="If the {} entity was deleted"
                              "successfully.".format(self.class_.title))]
             )
             self.supportedOperation.append(post_op)


### PR DESCRIPTION
This PR is a complementary PR to https://github.com/HTTP-APIs/hydrus/pull/488.



### Checklist
- [x] My branch is up-to-date with upstream/develop branch.
- [x] Everything works and tested for Python 3.5.2 and above.

### Description
<!-- Describe about what this PR does, previous state and new state of the output -->
- In the PR which addresses [treating collections as a resource](https://github.com/HTTP-APIs/hydrus/pull/488), support has been added in `hydrus` to perform **GET**, **PUT**, **POST** and **DELETE** operations on collections while treating them as a resource.
Essentially meaning, that now, **GET**, **PUT**, **POST** and **DELETE** operations can be performed on `/collection-class/:uuid` endpoints. (Before only **GET** and **PUT** operations were supported, that also only on `/collection/` endpoint only)


- Also, made default value of `readable` and `writeable` attributes of `member` property of `HydraCollection` class to True. This is done because now, as the collection will be treated as a resource, the `member` property should be readable and writeable to allow **GET** and **PUT** on it. 
<!-- #### Added -->
<!-- Edit these points below to describe the new features added with this PR -->
<!-- - Feature 1 -->
<!-- - Feature 2 -->


<!-- #### Changed -->
<!-- Edit these points below to describe the changes made in existing functionality with this PR -->
<!-- - Change 1 -->
<!-- - Change 1 -->


<!-- #### Fixed -->
<!-- Edit these points below to describe the bug fixes made with this PR -->
<!-- - Bug 1 -->


<!-- #### Removed -->
<!-- Edit these points below to describe the removed features with this PR -->
<!-- - Deprecated feature 1 -->
