### PR TITLE
Changed DocUrl for fragments

### DIFF
--- a/hydra_python_core/doc_writer.py
+++ b/hydra_python_core/doc_writer.py
@@ -381,10 +381,10 @@ class HydraEntryPoint():
         self.url = base_url
         self.api = entrypoint
         self.entrypoint = HydraClass("EntryPoint", "The main entry point or homepage of the API.",
-                                     _id="{}#EntryPoint".format(urljoin(self.url, self.api)))
+                                     _id="{}?resource=EntryPoint".format(urljoin(self.url, self.api)))
         self.entrypoint.add_supported_op(EntryPointOp(
             "_:entry_point".format(base_url), "GET", "The APIs main entry point.", None, None,
-            type_="{}/{}#EntryPoint".format(base_url, entrypoint)))
+            type_="{}/{}?resource=EntryPoint".format(base_url, entrypoint)))
         self.context = Context(
             "{}{}".format(
                 base_url,
@@ -427,7 +427,7 @@ class HydraEntryPoint():
         return self.entrypoint.generate()
 
     def get(self) -> Dict[str, str]:
-        """Create the EntryPoint object to be returnd for the get function."""
+        """Create the EntryPoint object to be returned for the get function."""
         object_ = {
             "@context": "{}{}/contexts/EntryPoint.jsonld".format(self.url,self.api),
             "@id": "{}{}".format(self.url,self.api),
@@ -438,8 +438,7 @@ class HydraEntryPoint():
             uri = item.id_
             if item.generate() in self.collections:
                 collection_returned = item.generate()
-                collection_id = uri.replace(
-                    "{}EntryPoint".format(DocUrl.doc_url), "{}{}".format(self.url,self.api))
+                collection_id = uri
                 collection_to_append = {
                     "@id": collection_id,
                     'title': collection_returned['hydra:title'],
@@ -454,9 +453,7 @@ class HydraEntryPoint():
                     object_['collections'].append(collection_to_append)
 
             else:
-                object_[item.name] = uri.replace(
-                    "{}EntryPoint".format(DocUrl.doc_url), "{}{}".format(self.url,self.api))
-
+                object_[item.name] = uri
         return object_
 
 
@@ -468,22 +465,13 @@ class EntryPointCollection():
         self.name = collection.name
         self.supportedOperation = collection.supportedOperation
         self.manages = collection.manages
-        if collection.path:
-            match_string = '(.+)(vocab\?resource=)(.+)'
-            id_ = "{}{}".format(DocUrl.doc_url, quote(collection.path, safe=''))
-            regex_groups = re.search(match_string,id_).groups()
-
-            self.id_ = regex_groups[0] + regex_groups[2]
-            self.base_url = regex_groups[0]
-
+        if collection.path: 
+            self.id_ = "{}EntryPoint/{}".format(DocUrl.doc_url, quote(collection.path, safe=''))
+            self.base_url = DocUrl.doc_url
         else:
-            match_string = '(.+)(vocab\?resource=)(.+)'
-            id_ = "{}{}".format(DocUrl.doc_url, quote(collection.path, safe=''))
-            regex_groups = re.search(match_string,id_).groups()
-
-            self.id_ = regex_groups[0] + regex_groups[2]
-            self.base_url = regex_groups[0]
-
+            self.id_ = "{}EntryPoint/{}".format(DocUrl.doc_url, quote(collection.path, safe=''))
+            self.base_url = DocUrl.doc_url
+    
     def generate(self) -> Dict[str, Any]:
         """Get as a python dict."""
         object_ = {
@@ -523,19 +511,12 @@ class EntryPointClass():
         self.desc = class_.desc
         self.supportedOperation = class_.supportedOperation
         if class_.path:
-            match_string = '(.+)(vocab\?resource=)(.+)'
-            id_ = "{}{}".format(DocUrl.doc_url, class_.path)
-            regex_groups = re.search(match_string,id_).groups()
-
-            self.id_ = regex_groups[0] + regex_groups[2]
-            self.base_url = regex_groups[0]
+            self.id_ = "{}EntryPoint/{}".format(DocUrl.doc_url, class_.path)
+            self.base_url = DocUrl.doc_url
         else:
-            match_string = '(.+)(\?resource=)(.+)'
-            id_ = "{}{}".format(DocUrl.doc_url, self.name)
-            regex_groups = re.search(match_string,id_).groups()
-            self.id_ = regex_groups[0] + regex_groups[2]
-            self.base_url = regex_groups[0]
-
+            self.id_ = "{}/EntryPoint/{}".format(DocUrl.doc_url, self.name)
+            self.base_url = DocUrl.doc_url
+          
     def generate(self) -> Dict[str, Any]:
         """Get as Python Dict."""
         object_ = {

--- a/hydra_python_core/doc_writer.py
+++ b/hydra_python_core/doc_writer.py
@@ -1,6 +1,7 @@
 """API Doc templates generator."""
 from typing import Any, Dict, List, Optional, Union
 from urllib.parse import quote, urljoin
+import re
 
 
 class HydraDoc:
@@ -468,15 +469,18 @@ class EntryPointCollection():
         self.supportedOperation = collection.supportedOperation
         self.manages = collection.manages
         if collection.path:
-            match_string = '(.+)(\?resource=)(.+)'
-            id_ = "{}EntryPoint/{}".format(DocUrl.doc_url, quote(collection.path, safe=''))
-            regex_groups = re.search(match_string,id_)
+            match_string = '(.+)(vocab\?resource=)(.+)'
+            id_ = "{}{}".format(DocUrl.doc_url, quote(collection.path, safe=''))
+            regex_groups = re.search(match_string,id_).groups()
+
             self.id_ = regex_groups[0] + regex_groups[2]
             self.base_url = regex_groups[0]
+
         else:
-            match_string = '(.+)(\?resource=)(.+)'
-            id_ = "{}EntryPoint/{}".format(DocUrl.doc_url, quote(self.name, safe=''))
-            regex_groups = re.search(match_string,id_)
+            match_string = '(.+)(vocab\?resource=)(.+)'
+            id_ = "{}{}".format(DocUrl.doc_url, quote(collection.path, safe=''))
+            regex_groups = re.search(match_string,id_).groups()
+
             self.id_ = regex_groups[0] + regex_groups[2]
             self.base_url = regex_groups[0]
 
@@ -488,7 +492,7 @@ class EntryPointCollection():
                 "@type": "hydra:Link",
                 "label": self.name,
                 "description": "The {} collection".format(self.name, ),
-                "domain": "{}EntryPoint".format(self.base_url),
+                "domain": "{}EntryPoint".format(DocUrl.doc_url),
                 "range": "{}{}".format(DocUrl.doc_url, self.name),
                 "manages": self.manages,
                 "supportedOperation": [],
@@ -519,15 +523,16 @@ class EntryPointClass():
         self.desc = class_.desc
         self.supportedOperation = class_.supportedOperation
         if class_.path:
-            match_string = '(.+)(\?resource=)(.+)'
-            id_ = "{}EntryPoint/{}".format(DocUrl.doc_url, class_.path)
-            regex_groups = re.search(match_string,id_)
+            match_string = '(.+)(vocab\?resource=)(.+)'
+            id_ = "{}{}".format(DocUrl.doc_url, class_.path)
+            regex_groups = re.search(match_string,id_).groups()
+
             self.id_ = regex_groups[0] + regex_groups[2]
             self.base_url = regex_groups[0]
         else:
             match_string = '(.+)(\?resource=)(.+)'
-            id_ = "{}EntryPoint/{}".format(DocUrl.doc_url, self.name)
-            regex_groups = re.search(match_string,id_)
+            id_ = "{}{}".format(DocUrl.doc_url, self.name)
+            regex_groups = re.search(match_string,id_).groups()
             self.id_ = regex_groups[0] + regex_groups[2]
             self.base_url = regex_groups[0]
 
@@ -768,13 +773,9 @@ class Context():
                             collection.name: collection.collection_id}
 
         elif entrypoint is not None:
-            match_string = '(.+)(\?resource=)(.+)'
             entrypoint = "{}EntryPoint".format(DocUrl.doc_url)
-            regex_groups = re.search(match_string,entrypoint)
-
-
             self.context = {
-                "EntryPoint": regex_groups[0] + regex_groups[2],
+                "EntryPoint": entrypoint,
             }
 
         else:

--- a/hydra_python_core/doc_writer.py
+++ b/hydra_python_core/doc_writer.py
@@ -468,9 +468,17 @@ class EntryPointCollection():
         self.supportedOperation = collection.supportedOperation
         self.manages = collection.manages
         if collection.path:
-            self.id_ = "{}EntryPoint/{}".format(DocUrl.doc_url, quote(collection.path, safe=''))
+            match_string = '(.+)(\?resource=)(.+)'
+            id_ = "{}EntryPoint/{}".format(DocUrl.doc_url, quote(collection.path, safe=''))
+            regex_groups = re.search(match_string,id_)
+            self.id_ = regex_groups[0] + regex_groups[2]
+            self.base_url = regex_groups[0]
         else:
-            self.id_ = "{}EntryPoint/{}".format(DocUrl.doc_url, quote(self.name, safe=''))
+            match_string = '(.+)(\?resource=)(.+)'
+            id_ = "{}EntryPoint/{}".format(DocUrl.doc_url, quote(self.name, safe=''))
+            regex_groups = re.search(match_string,id_)
+            self.id_ = regex_groups[0] + regex_groups[2]
+            self.base_url = regex_groups[0]
 
     def generate(self) -> Dict[str, Any]:
         """Get as a python dict."""
@@ -480,7 +488,7 @@ class EntryPointCollection():
                 "@type": "hydra:Link",
                 "label": self.name,
                 "description": "The {} collection".format(self.name, ),
-                "domain": "{}EntryPoint".format(DocUrl.doc_url),
+                "domain": "{}EntryPoint".format(self.base_url),
                 "range": "{}{}".format(DocUrl.doc_url, self.name),
                 "manages": self.manages,
                 "supportedOperation": [],
@@ -511,9 +519,17 @@ class EntryPointClass():
         self.desc = class_.desc
         self.supportedOperation = class_.supportedOperation
         if class_.path:
-            self.id_ = "{}EntryPoint/{}".format(DocUrl.doc_url, class_.path)
+            match_string = '(.+)(\?resource=)(.+)'
+            id_ = "{}EntryPoint/{}".format(DocUrl.doc_url, class_.path)
+            regex_groups = re.search(match_string,id_)
+            self.id_ = regex_groups[0] + regex_groups[2]
+            self.base_url = regex_groups[0]
         else:
-            self.id_ = "{}EntryPoint/{}".format(DocUrl.doc_url, self.name)
+            match_string = '(.+)(\?resource=)(.+)'
+            id_ = "{}EntryPoint/{}".format(DocUrl.doc_url, self.name)
+            regex_groups = re.search(match_string,id_)
+            self.id_ = regex_groups[0] + regex_groups[2]
+            self.base_url = regex_groups[0]
 
     def generate(self) -> Dict[str, Any]:
         """Get as Python Dict."""
@@ -523,7 +539,7 @@ class EntryPointClass():
                 "@type": "hydra:Link",
                 "label": self.name,
                 "description": self.desc,
-                "domain": "{}EntryPoint".format(DocUrl.doc_url),
+                "domain": "{}EntryPoint".format(self.base_url),
                 "range": "{}{}".format(DocUrl.doc_url, self.name),
                 "supportedOperation": []
             },
@@ -752,8 +768,13 @@ class Context():
                             collection.name: collection.collection_id}
 
         elif entrypoint is not None:
+            match_string = '(.+)(\?resource=)(.+)'
+            entrypoint = "{}EntryPoint".format(DocUrl.doc_url)
+            regex_groups = re.search(match_string,entrypoint)
+
+
             self.context = {
-                "EntryPoint": "{}EntryPoint".format(DocUrl.doc_url),
+                "EntryPoint": regex_groups[0] + regex_groups[2],
             }
 
         else:
@@ -839,4 +860,4 @@ class DocUrl:
     doc_url = ''
 
     def __init__(self, base_url: str, api_name: str, doc_name: str) -> None:
-        DocUrl.doc_url = "{}/{}#".format(urljoin(base_url, api_name), doc_name)
+        DocUrl.doc_url = "{}/{}?resource=".format(urljoin(base_url, api_name), doc_name)

--- a/tests/test_doc_maker.py
+++ b/tests/test_doc_maker.py
@@ -390,5 +390,31 @@ class TestCreateStatus(unittest.TestCase):
         self.assertIsInstance(obj[0], doc_writer.HydraStatus)
 
 
+class TestFragments(unittest.TestCase):
+    """
+        Test Class for checking fragments in id's
+    """
+    def test_fragments(self):
+        server_url = "http://hydrus.com/"
+        api_name = "test_api"
+        self.doc = doc_writer_sample_output.doc
+        apidoc = doc_maker.create_doc(self.doc, server_url, api_name)
+        for class_ in apidoc.parsed_classes:
+            resource = apidoc.parsed_classes[class_]['class']
+            resource_id = resource.id_
+            regex = r"(\W*\?resource=\W*)([a-zA-Z]+)"
+            match_groups = re.search(regex, resource_id)
+            
+            assert match_groups.groups()[0] is not None
+            assert match_groups.groups()[1] == class_
+        
+        for collection in apidoc.collections:
+            resource_id = apidoc.collections[collection]['collection'].collection_id
+            regex = r"(\W*\?resource=\W*)([a-zA-Z]+)"
+            match_groups = re.search(regex, resource_id)
+            
+            assert match_groups.groups()[0] is not None
+            assert match_groups.groups()[1] == collection
+            
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
<!-- Please create/claim an issue before sending a PR -->
<!-- Add issue number (Eg: fixes #123) -->

There is in reference to a [PR in the hydrus repo](https://github.com/HTTP-APIs/hydrus/pull/518) 
### Checklist
- [x] My branch is up-to-date with upstream/develop branch.
- [x] Everything works and tested for Python 3.5.2 and above.

### Description
<!-- Describe about what this PR does, previous state and new state of the output -->
This PR is added so that fragments of vocab can be identified. I have changed the DocUrl.
Old format of ids:
```http//petstore.swagger.io/vocab#UserCollection```
New format of ids:
```http//petstore.swagger.io/vocab?resource=UserCollection```

I also found that there were some errors with the EntryPoint id's so I tried fixing that using regex as you can see. The error was that the entrypoints were shown as ```http//petstore.swagger.io/vocab?resource=EntryPoint/UserCollection``` which I tried changing to ```http//petstore.swagger.io/vocab/EntryPoint/UserCollection```. I am not entirely sure if this solves every problem but I did go through the doc returned and tried solving as many issues I could. Let me know if my solution needs to be changed.
### Change logs

<!-- #### Added -->
<!-- Edit these points below to describe the new features added with this PR -->
<!-- - Feature 1 -->
<!-- - Feature 2 -->


#### Changed 
<!-- Edit these points below to describe the changes made in existing functionality with this PR -->
<!-- - Change 1 -->
- DocUrl was changed from:
```DocUrl.doc_url = "{}/{}#".format(urljoin(base_url, api_name), doc_name)``` 
to
```DocUrl.doc_url = "{}/{}?resource=".format(urljoin(base_url, api_name), doc_name)```

<!-- #### Fixed -->
<!-- Edit these points below to describe the bug fixes made with this PR -->
<!-- - Bug 1 -->


<!-- #### Removed -->
<!-- Edit these points below to describe the removed features with this PR -->
<!-- - Deprecated feature 1 -->
