### PR TITLE
Propuri

### DIFF
--- a/samples/doc_writer_sample.py
+++ b/samples/doc_writer_sample.py
@@ -87,7 +87,7 @@ dummyProp1 = HydraClassProp(prop1_uri, prop1_title,
 prop2_uri = "http://props.hydrus.com/prop2"
 prop2_title = "Prop2"
 
-dummyProp2 = HydraClassProp(prop1_uri, prop2_title,
+dummyProp2 = HydraClassProp(prop2_uri, prop2_title,
                             required=False, read=False, write=True)
 # NOTE: Properties that are required=True must be added during class object creation
 #       Properties that are read=True are read only
@@ -198,5 +198,5 @@ if __name__ == "__main__":
     doc = doc.replace('true', '"true"')
     doc = doc.replace('false', '"false"')
     doc = doc.replace('null', '"null"')
-    with open("samples/doc_writer_sample_output.py", "w") as f:
+    with open("doc_writer_sample_output.py", "w") as f:
         f.write(doc)

--- a/samples/doc_writer_sample.py
+++ b/samples/doc_writer_sample.py
@@ -198,5 +198,5 @@ if __name__ == "__main__":
     doc = doc.replace('true', '"true"')
     doc = doc.replace('false', '"false"')
     doc = doc.replace('null', '"null"')
-    with open("doc_writer_sample_output.py", "w") as f:
+    with open("samples/doc_writer_sample_output.py", "w") as f:
         f.write(doc)

--- a/samples/doc_writer_sample_output.py
+++ b/samples/doc_writer_sample_output.py
@@ -157,7 +157,7 @@ doc = {
                 },
                 {
                     "@type": "SupportedProperty",
-                    "property": "http://props.hydrus.com/prop1",
+                    "property": "http://props.hydrus.com/prop2",
                     "readable": "false",
                     "required": "false",
                     "title": "Prop2",
@@ -263,7 +263,7 @@ doc = {
                 },
                 {
                     "@type": "SupportedProperty",
-                    "property": "http://props.hydrus.com/prop1",
+                    "property": "http://props.hydrus.com/prop2",
                     "readable": "false",
                     "required": "false",
                     "title": "Prop2",


### PR DESCRIPTION
<!-- Please create/claim an issue before sending a PR -->
<!-- Add issue number (Eg: fixes #123) -->

Fixes #

### Checklist
- [x] My branch is up-to-date with upstream/develop branch.
- [x] Everything works and tested for Python 3.5.2 and above.

### Description
<!-- Describe about what this PR does, previous state and new state of the output -->
In _samples/doc_writer_sample.py_ the prop_uri for both dummyProp1 and dummyProp2 properties was set to prop1_uri in `HydraClassProp`. This was just a small typo and a similar changed was also made in hydrus in this [PR](https://github.com/HTTP-APIs/hydrus/pull/524) .

### Change logs

<!-- #### Added -->
<!-- Edit these points below to describe the new features added with this PR -->
<!-- - Feature 1 -->
<!-- - Feature 2 -->


<!-- #### Changed -->
<!-- Edit these points below to describe the changes made in existing functionality with this PR -->
<!-- - Change 1 -->
<!-- - Change 1 -->


<!-- #### Fixed -->
<!-- Edit these points below to describe the bug fixes made with this PR -->
<!-- - Bug 1 -->


<!-- #### Removed -->
<!-- Edit these points below to describe the removed features with this PR -->
<!-- - Deprecated feature 1 -->
