### PR TITLE
chore: wrong import docs HydraClass

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -216,22 +216,22 @@ Other than this, an API Documentation also needs to have the Resource and the Co
     :linenos:
 
     # Other operations
-    apidoc.add_baseResource()  # Creates the base Resource Class and adds it to the API Documentation
-    apidoc.add_baseCollection()    # Creates the base Collection Class and adds it to the API Documentation
+    api_doc.add_baseResource()  # Creates the base Resource Class and adds it to the API Documentation
+    api_doc.add_baseCollection()    # Creates the base Collection Class and adds it to the API Documentation
 
 Finally, create the EntryPoint object for the API Documentation. All Collections are automatically assigned endpoints in the EntryPoint object. Classes that had their endpoint variables set to True are also assigned endpoints in the EntryPoint object. This object is created automatically by the HydraDoc object and can be created using the gen_EntryPoint method.
 
 .. code-block:: python
     :linenos:
 
-    apidoc.gen_EntryPoint()    # Generates the EntryPoint object for the Doc using the Classes and Collections
+    api_doc.gen_EntryPoint()    # Generates the EntryPoint object for the Doc using the Classes and Collections
 
 The final API Documentation can be viewed by calling the generate method which returns a Python dictionary containing the entire API Documentation. The generate method can be called for every class defined in the doc_writer module to generate its own Python dictionary.
 
 .. code-block:: python
     :linenos:
 
-    doc = apidoc.generate()
+    doc = api_doc.generate()
 
 The complete script for this API Documentation can be found in ``samples/doc_writer_sample.py``, and the generated ApiDocumentation can be found in ``samples/doc_writer_sample_output.py``.
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -121,7 +121,7 @@ The API Documentation has been created, but it is not yet complete. Classes, pro
 .. code-block:: python
     :linenos:
 
-    from hydra_python_core.doc_writer import HydraDoc
+    from hydra_python_core.doc_writer import HydraClass
     # Creating classes for the API
     class_title = "dummyClass"                      # Title of the Class
     class_description = "A dummyClass for demo"     # Description of the class


### PR DESCRIPTION
HydraDoc was imported instead of HydraClass

<!-- Please create/claim an issue before sending a PR -->
<!-- Add issue number (Eg: fixes #123) -->

Fixes #67 

### Checklist
- [x] My branch is up-to-date with upstream/develop branch.
- [x] Everything works and tested for Python 3.5.2 and above.

### Description
<!-- Describe about what this PR does, previous state and new state of the output -->
Correctly import HydraClass instead of HydraDoc

### Change logs

<!-- #### Added -->
<!-- Edit these points below to describe the new features added with this PR -->
<!-- - Feature 1 -->
<!-- - Feature 2 -->


<!-- #### Changed -->
<!-- Edit these points below to describe the changes made in existing functionality with this PR -->
<!-- - Change 1 -->
<!-- - Change 1 -->


<!-- #### Fixed -->
<!-- Edit these points below to describe the bug fixes made with this PR -->
<!-- - Bug 1 -->


<!-- #### Removed -->
<!-- Edit these points below to describe the removed features with this PR -->
<!-- - Deprecated feature 1 -->
