### PR TITLE
Set readable and writeable to True for supportedProperty of HydraCollection

### DIFF
--- a/hydra_python_core/doc_writer.py
+++ b/hydra_python_core/doc_writer.py
@@ -277,7 +277,7 @@ class HydraCollection():
         self.supportedOperation = list()  # type: List
         self.supportedProperty = [HydraClassProp("http://www.w3.org/ns/hydra/core#member",
                                                  "members",
-                                                 False, False, False,
+                                                  True, True, False,
                                                  "The members of {}".format(collection_name))]
         self.manages = manages
 


### PR DESCRIPTION
<!-- Please create/claim an issue before sending a PR -->
<!-- Add issue number (Eg: fixes #123) -->

Fixes #70

### Checklist
- [x] My branch is up-to-date with upstream/develop branch.
- [x] Everything works and tested for Python 3.5.2 and above.

### Description
<!-- Describe about what this PR does, previous state and new state of the output -->
`writeable` and `readable` attribute for HydraClassProp are set to True in `suppportedProperty` of HydraCollection.
hydrus checks that a Collection should have only writeable properties to make a POST/DELETE request to a collection endpoint.
### Change logs
doc_writer.py : attribute for supportedProperty changed in HydraCollection class
<!-- #### Added -->
<!-- Edit these points below to describe the new features added with this PR -->
<!-- - Feature 1 -->
<!-- - Feature 2 -->


<!-- #### Changed -->
<!-- Edit these points below to describe the changes made in existing functionality with this PR -->
<!-- - Change 1 -->
<!-- - Change 1 -->


<!-- #### Fixed -->
<!-- Edit these points below to describe the bug fixes made with this PR -->
<!-- - Bug 1 -->


<!-- #### Removed -->
<!-- Edit these points below to describe the removed features with this PR -->
<!-- - Deprecated feature 1 -->
