### PR TITLE
TypeError fixed, changed parameter from dict to str.

### DIFF
--- a/hydra_python_core/doc_maker.py
+++ b/hydra_python_core/doc_maker.py
@@ -107,7 +107,7 @@ def create_doc(doc: Dict[str, Any], HYDRUS_SERVER_URL: str = None,
             API_NAME, _title, _description, API_NAME, HYDRUS_SERVER_URL, doc_name)
     else:
         apidoc = HydraDoc(
-            entrypoint, _title, _description, entrypoint, base_url, doc_name)
+            entrypoint['@id'], _title, _description, entrypoint['@id'], base_url, doc_name)
 
     # additional context entries
     for entry in _context:

--- a/hydra_python_core/doc_maker.py
+++ b/hydra_python_core/doc_maker.py
@@ -105,9 +105,11 @@ def create_doc(doc: Dict[str, Any], HYDRUS_SERVER_URL: str = None,
     if HYDRUS_SERVER_URL is not None and API_NAME is not None:
         apidoc = HydraDoc(
             API_NAME, _title, _description, API_NAME, HYDRUS_SERVER_URL, doc_name)
-    else:
+    elif entrypoint.get('@id'):
         apidoc = HydraDoc(
-            entrypoint['@id'], _title, _description, entrypoint['@id'], base_url, doc_name)
+            entrypoint.get('@id'), _title, _description, entrypoint.get('@id'), base_url, doc_name)
+    else:
+        print("No EntryPoint found, please set the API variables.")
 
     # additional context entries
     for entry in _context:

--- a/hydra_python_core/doc_maker.py
+++ b/hydra_python_core/doc_maker.py
@@ -109,7 +109,7 @@ def create_doc(doc: Dict[str, Any], HYDRUS_SERVER_URL: str = None,
         apidoc = HydraDoc(
             entrypoint.get('@id'), _title, _description, entrypoint.get('@id'), base_url, doc_name)
     else:
-        print("No EntryPoint found, please set the API variables.")
+        raise Exception("No EntryPoint found, please set the API variables.")
 
     # additional context entries
     for entry in _context:


### PR DESCRIPTION
<!-- Please create/claim an issue before sending a PR -->
<!-- Add issue number (Eg: fixes #123) -->

Fixes #72

### Checklist
- [x] My branch is up-to-date with upstream/develop branch.
- [x] Everything works and tested for Python 3.5.2 and above.

### Description
<!-- Describe about what this PR does, previous state and new state of the output -->

If we don't set the API variable then the default variables are being passed. but the default API name is passed as **dict** whereas it should be **str**.

![Screenshot from 2021-04-14 17-50-53](https://user-images.githubusercontent.com/49719371/114851552-965f9580-9dff-11eb-8120-79ec96990ca7.jpg)


### Change logs
change `entrypoint` argument to `entrypoint['@id']` in doc_maker.py


<!-- #### Added -->
<!-- Edit these points below to describe the new features added with this PR -->
<!-- - Feature 1 -->
<!-- - Feature 2 -->


<!-- #### Changed -->
<!-- Edit these points below to describe the changes made in existing functionality with this PR -->
<!-- - Change 1 -->
<!-- - Change 1 -->


<!-- #### Fixed -->
<!-- Edit these points below to describe the bug fixes made with this PR -->
<!-- - Bug 1 -->


<!-- #### Removed -->
<!-- Edit these points below to describe the removed features with this PR -->
<!-- - Deprecated feature 1 -->
