### PR TITLE
Added support for datatype(range) in supported properties

### DIFF
--- a/hydra_python_core/doc_maker.py
+++ b/hydra_python_core/doc_maker.py
@@ -331,20 +331,23 @@ def create_property(supported_property: Dict[str, Any]) -> Union[HydraLink, Hydr
     prop_read = supported_property[hydra['readable']][0]['@value']
     prop_require = supported_property[hydra['required']][0]['@value']
     prop_write = supported_property[hydra['writeable']][0]['@value']
-    if rdfs['range'] in supported_property:
-        prop_range = supported_property[rdfs['range']][0]['@id']
-        prop_ = HydraClassProp(prop=prop_id,
-                               title=prop_title,
-                               required=prop_require,
-                               read=prop_read,
-                               write=prop_write,
-                               range=prop_range)
-    else:
-        prop_ = HydraClassProp(prop=prop_id,
-                               title=prop_title,
-                               required=prop_require,
-                               read=prop_read,
-                               write=prop_write)
+
+    for namespace in supported_property:
+        if "range" in namespace:
+            prop_range = supported_property[namespace][0]['@id']
+            prop_ = HydraClassProp(prop=prop_id,
+                                   title=prop_title,
+                                   required=prop_require,
+                                   read=prop_read,
+                                   write=prop_write,
+                                   range=prop_range)
+            return prop_
+
+    prop_ = HydraClassProp(prop=prop_id,
+                           title=prop_title,
+                           required=prop_require,
+                           read=prop_read,
+                           write=prop_write)
     return prop_
 
 

--- a/hydra_python_core/doc_maker.py
+++ b/hydra_python_core/doc_maker.py
@@ -331,12 +331,20 @@ def create_property(supported_property: Dict[str, Any]) -> Union[HydraLink, Hydr
     prop_read = supported_property[hydra['readable']][0]['@value']
     prop_require = supported_property[hydra['required']][0]['@value']
     prop_write = supported_property[hydra['writeable']][0]['@value']
-
-    prop_ = HydraClassProp(prop=prop_id,
-                           title=prop_title,
-                           required=prop_require,
-                           read=prop_read,
-                           write=prop_write)
+    if rdfs['range'] in supported_property:
+        prop_range = supported_property[rdfs['range']][0]['@id']
+        prop_ = HydraClassProp(prop=prop_id,
+                               title=prop_title,
+                               required=prop_require,
+                               read=prop_read,
+                               write=prop_write,
+                               range=prop_range)
+    else:
+        prop_ = HydraClassProp(prop=prop_id,
+                               title=prop_title,
+                               required=prop_require,
+                               read=prop_read,
+                               write=prop_write)
     return prop_
 
 

--- a/hydra_python_core/doc_writer.py
+++ b/hydra_python_core/doc_writer.py
@@ -186,7 +186,7 @@ class HydraClassProp():
                  write: bool,
                  required: bool,
                  desc: str = "",
-                 ) -> None:
+                 **kwargs) -> None:
         """Initialize the Hydra_Prop."""
         self.prop = prop
         self.title = title
@@ -194,6 +194,7 @@ class HydraClassProp():
         self.write = write
         self.required = required
         self.desc = desc
+        self.kwargs = kwargs
 
     def generate(self) -> Dict[str, Any]:
         """Get the Hydra prop as a python dict."""
@@ -210,6 +211,8 @@ class HydraClassProp():
             prop["property"] = self.prop
         if len(self.desc) > 0:
             prop["description"] = self.desc
+        if "range" in self.kwargs:
+            prop["range"] = self.kwargs["range"]
         return prop
 
 
@@ -781,6 +784,7 @@ class Context():
                 "supportedOperation": "hydra:supportedOperation",
                 "label": "rdfs:label",
                 "rdf": "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
+                "xsd": "https://www.w3.org/TR/xmlschema-2/#",
                 "domain": {
                     "@type": "@id",
                     "@id": "rdfs:domain"

--- a/hydra_python_core/namespace.py
+++ b/hydra_python_core/namespace.py
@@ -71,6 +71,7 @@ hydra = {
     "search": hydraNamespace + "search",
     "view": hydraNamespace + "view"
 }
+
 rdfNamespace = "http://www.w3.org/1999/02/22-rdf-syntax-ns#"
 
 rdf = {

--- a/samples/doc_writer_sample_output.py
+++ b/samples/doc_writer_sample_output.py
@@ -77,7 +77,7 @@ doc = {
                     "method": "POST",
                     "possibleStatus": [
                         {
-                            "@context": "https://raw.githubusercontent.com/HydraCG/Specifications/master/spec/latest/core/core.jsonld",
+                            "@context": "https://www.w3.org/ns/hydra/core",
                             "@type": "Status",
                             "description": "dummyClass updated.",
                             "statusCode": 200,
@@ -98,7 +98,7 @@ doc = {
                     "method": "DELETE",
                     "possibleStatus": [
                         {
-                            "@context": "https://raw.githubusercontent.com/HydraCG/Specifications/master/spec/latest/core/core.jsonld",
+                            "@context": "https://www.w3.org/ns/hydra/core",
                             "@type": "Status",
                             "description": "dummyClass deleted.",
                             "statusCode": 200,
@@ -116,7 +116,7 @@ doc = {
                     "method": "PUT",
                     "possibleStatus": [
                         {
-                            "@context": "https://raw.githubusercontent.com/HydraCG/Specifications/master/spec/latest/core/core.jsonld",
+                            "@context": "https://www.w3.org/ns/hydra/core",
                             "@type": "Status",
                             "description": "dummyClass successfully added.",
                             "statusCode": 201,
@@ -134,7 +134,7 @@ doc = {
                     "method": "GET",
                     "possibleStatus": [
                         {
-                            "@context": "https://raw.githubusercontent.com/HydraCG/Specifications/master/spec/latest/core/core.jsonld",
+                            "@context": "https://www.w3.org/ns/hydra/core",
                             "@type": "Status",
                             "description": "dummyClass returned.",
                             "statusCode": 200,
@@ -186,7 +186,7 @@ doc = {
                     "method": "POST",
                     "possibleStatus": [
                         {
-                            "@context": "https://raw.githubusercontent.com/HydraCG/Specifications/master/spec/latest/core/core.jsonld",
+                            "@context": "https://www.w3.org/ns/hydra/core",
                             "@type": "Status",
                             "description": "singleClass changed.",
                             "statusCode": 200,
@@ -204,7 +204,7 @@ doc = {
                     "method": "DELETE",
                     "possibleStatus": [
                         {
-                            "@context": "https://raw.githubusercontent.com/HydraCG/Specifications/master/spec/latest/core/core.jsonld",
+                            "@context": "https://www.w3.org/ns/hydra/core",
                             "@type": "Status",
                             "description": "singleClass deleted.",
                             "statusCode": 200,
@@ -222,7 +222,7 @@ doc = {
                     "method": "PUT",
                     "possibleStatus": [
                         {
-                            "@context": "https://raw.githubusercontent.com/HydraCG/Specifications/master/spec/latest/core/core.jsonld",
+                            "@context": "https://www.w3.org/ns/hydra/core",
                             "@type": "Status",
                             "description": "singleClass successfully added.",
                             "statusCode": 201,
@@ -240,7 +240,7 @@ doc = {
                     "method": "GET",
                     "possibleStatus": [
                         {
-                            "@context": "https://raw.githubusercontent.com/HydraCG/Specifications/master/spec/latest/core/core.jsonld",
+                            "@context": "https://www.w3.org/ns/hydra/core",
                             "@type": "Status",
                             "description": "singleClass returned.",
                             "statusCode": 200,
@@ -308,7 +308,7 @@ doc = {
                     "method": "GET",
                     "possibleStatus": [
                         {
-                            "@context": "https://raw.githubusercontent.com/HydraCG/Specifications/master/spec/latest/core/core.jsonld",
+                            "@context": "https://www.w3.org/ns/hydra/core",
                             "@type": "Status",
                             "description": "anotherSingleClass returned.",
                             "statusCode": 200,
@@ -387,7 +387,7 @@ doc = {
                     "method": "PUT",
                     "possibleStatus": [
                         {
-                            "@context": "https://raw.githubusercontent.com/HydraCG/Specifications/master/spec/latest/core/core.jsonld",
+                            "@context": "https://www.w3.org/ns/hydra/core",
                             "@type": "Status",
                             "description": "A new member in Extraclasses created",
                             "statusCode": 201,
@@ -406,7 +406,7 @@ doc = {
                     "method": "POST",
                     "possibleStatus": [
                         {
-                            "@context": "https://raw.githubusercontent.com/HydraCG/Specifications/master/spec/latest/core/core.jsonld",
+                            "@context": "https://www.w3.org/ns/hydra/core",
                             "@type": "Status",
                             "description": "If the entity was updatedfrom Extraclasses.",
                             "statusCode": 200,
@@ -425,7 +425,7 @@ doc = {
                     "method": "DELETE",
                     "possibleStatus": [
                         {
-                            "@context": "https://raw.githubusercontent.com/HydraCG/Specifications/master/spec/latest/core/core.jsonld",
+                            "@context": "https://www.w3.org/ns/hydra/core",
                             "@type": "Status",
                             "description": "If entity was deletedsuccessfully from Extraclasses.",
                             "statusCode": 200,
@@ -479,7 +479,7 @@ doc = {
                     "method": "PUT",
                     "possibleStatus": [
                         {
-                            "@context": "https://raw.githubusercontent.com/HydraCG/Specifications/master/spec/latest/core/core.jsonld",
+                            "@context": "https://www.w3.org/ns/hydra/core",
                             "@type": "Status",
                             "description": "A new member in dummyclasses created",
                             "statusCode": 201,
@@ -498,7 +498,7 @@ doc = {
                     "method": "POST",
                     "possibleStatus": [
                         {
-                            "@context": "https://raw.githubusercontent.com/HydraCG/Specifications/master/spec/latest/core/core.jsonld",
+                            "@context": "https://www.w3.org/ns/hydra/core",
                             "@type": "Status",
                             "description": "If the entity was updatedfrom dummyclasses.",
                             "statusCode": 200,
@@ -517,7 +517,7 @@ doc = {
                     "method": "DELETE",
                     "possibleStatus": [
                         {
-                            "@context": "https://raw.githubusercontent.com/HydraCG/Specifications/master/spec/latest/core/core.jsonld",
+                            "@context": "https://www.w3.org/ns/hydra/core",
                             "@type": "Status",
                             "description": "If entity was deletedsuccessfully from dummyclasses.",
                             "statusCode": 200,
@@ -580,7 +580,7 @@ doc = {
                                 "method": "POST",
                                 "possibleStatus": [
                                     {
-                                        "@context": "https://raw.githubusercontent.com/HydraCG/Specifications/master/spec/latest/core/core.jsonld",
+                                        "@context": "https://www.w3.org/ns/hydra/core",
                                         "@type": "Status",
                                         "description": "singleClass changed.",
                                         "statusCode": 200,
@@ -600,7 +600,7 @@ doc = {
                                 "method": "DELETE",
                                 "possibleStatus": [
                                     {
-                                        "@context": "https://raw.githubusercontent.com/HydraCG/Specifications/master/spec/latest/core/core.jsonld",
+                                        "@context": "https://www.w3.org/ns/hydra/core",
                                         "@type": "Status",
                                         "description": "singleClass deleted.",
                                         "statusCode": 200,
@@ -620,7 +620,7 @@ doc = {
                                 "method": "PUT",
                                 "possibleStatus": [
                                     {
-                                        "@context": "https://raw.githubusercontent.com/HydraCG/Specifications/master/spec/latest/core/core.jsonld",
+                                        "@context": "https://www.w3.org/ns/hydra/core",
                                         "@type": "Status",
                                         "description": "singleClass successfully added.",
                                         "statusCode": 201,
@@ -640,7 +640,7 @@ doc = {
                                 "method": "GET",
                                 "possibleStatus": [
                                     {
-                                        "@context": "https://raw.githubusercontent.com/HydraCG/Specifications/master/spec/latest/core/core.jsonld",
+                                        "@context": "https://www.w3.org/ns/hydra/core",
                                         "@type": "Status",
                                         "description": "singleClass returned.",
                                         "statusCode": 200,
@@ -677,7 +677,7 @@ doc = {
                                 "method": "GET",
                                 "possibleStatus": [
                                     {
-                                        "@context": "https://raw.githubusercontent.com/HydraCG/Specifications/master/spec/latest/core/core.jsonld",
+                                        "@context": "https://www.w3.org/ns/hydra/core",
                                         "@type": "Status",
                                         "description": "anotherSingleClass returned.",
                                         "statusCode": 200,
@@ -728,7 +728,7 @@ doc = {
                                 "method": "PUT",
                                 "possibleStatus": [
                                     {
-                                        "@context": "https://raw.githubusercontent.com/HydraCG/Specifications/master/spec/latest/core/core.jsonld",
+                                        "@context": "https://www.w3.org/ns/hydra/core",
                                         "@type": "Status",
                                         "description": "A new member in Extraclasses created",
                                         "statusCode": 201,
@@ -747,7 +747,7 @@ doc = {
                                 "method": "POST",
                                 "possibleStatus": [
                                     {
-                                        "@context": "https://raw.githubusercontent.com/HydraCG/Specifications/master/spec/latest/core/core.jsonld",
+                                        "@context": "https://www.w3.org/ns/hydra/core",
                                         "@type": "Status",
                                         "description": "If the entity was updatedfrom Extraclasses.",
                                         "statusCode": 200,
@@ -766,7 +766,7 @@ doc = {
                                 "method": "DELETE",
                                 "possibleStatus": [
                                     {
-                                        "@context": "https://raw.githubusercontent.com/HydraCG/Specifications/master/spec/latest/core/core.jsonld",
+                                        "@context": "https://www.w3.org/ns/hydra/core",
                                         "@type": "Status",
                                         "description": "If entity was deletedsuccessfully from Extraclasses.",
                                         "statusCode": 200,
@@ -817,7 +817,7 @@ doc = {
                                 "method": "PUT",
                                 "possibleStatus": [
                                     {
-                                        "@context": "https://raw.githubusercontent.com/HydraCG/Specifications/master/spec/latest/core/core.jsonld",
+                                        "@context": "https://www.w3.org/ns/hydra/core",
                                         "@type": "Status",
                                         "description": "A new member in dummyclasses created",
                                         "statusCode": 201,
@@ -836,7 +836,7 @@ doc = {
                                 "method": "POST",
                                 "possibleStatus": [
                                     {
-                                        "@context": "https://raw.githubusercontent.com/HydraCG/Specifications/master/spec/latest/core/core.jsonld",
+                                        "@context": "https://www.w3.org/ns/hydra/core",
                                         "@type": "Status",
                                         "description": "If the entity was updatedfrom dummyclasses.",
                                         "statusCode": 200,
@@ -855,7 +855,7 @@ doc = {
                                 "method": "DELETE",
                                 "possibleStatus": [
                                     {
-                                        "@context": "https://raw.githubusercontent.com/HydraCG/Specifications/master/spec/latest/core/core.jsonld",
+                                        "@context": "https://www.w3.org/ns/hydra/core",
                                         "@type": "Status",
                                         "description": "If entity was deletedsuccessfully from dummyclasses.",
                                         "statusCode": 200,

--- a/tests/test_doc_writer.py
+++ b/tests/test_doc_writer.py
@@ -23,6 +23,7 @@ class TestDocWriter(unittest.TestCase):
             'supportedOperation': 'hydra:supportedOperation',
             'label': 'rdfs:label',
             'rdf': 'http://www.w3.org/1999/02/22-rdf-syntax-ns#',
+            "xsd": "https://www.w3.org/TR/xmlschema-2/#",
             'domain': {
                 '@type': '@id',
                 '@id': 'rdfs:domain'


### PR DESCRIPTION
<!-- Please create/claim an issue before sending a PR -->
<!-- Add issue number (Eg: fixes #123) -->

Fixes #88 

### Checklist
- [x] My branch is up-to-date with upstream/develop branch.
- [x] Everything works and tested for Python 3.5.2 and above.

### Description
<!-- Describe about what this PR does, previous state and new state of the output -->
Database columns should be created with datatype as String, Integer or Float according to types defined in the ApiDoc or Ontology via properties like `"range":  "xsd:decimal"` as discussed. For this implementation changes have to be made in both doc_writer and doc_maker.
```
{
      "@type": "SupportedProperty",
      "property": "URL..../NonPerformingLoan.jsonld#LegalEntityIdentifier",
      "range": "https://www.w3.org/TR/xmlschema-2/#integer",
      "readable": "true",
      "required": "true",
      "title": "LegalEntityIdentifier",
      "writeable": "true"
}
```
### Change logs
- Added `xsd` to Context
- Changes in HydraClassProp in doc_writer
- Changes in create_property function in doc_maker
- Updated sample docs with w3.org `@context` in HydraStatus
<!-- #### Added -->
<!-- Edit these points below to describe the new features added with this PR -->
<!-- - Feature 1 -->
<!-- - Feature 2 -->


<!-- #### Changed -->
<!-- Edit these points below to describe the changes made in existing functionality with this PR -->
<!-- - Change 1 -->
<!-- - Change 1 -->


<!-- #### Fixed -->
<!-- Edit these points below to describe the bug fixes made with this PR -->
<!-- - Bug 1 -->


<!-- #### Removed -->
<!-- Edit these points below to describe the removed features with this PR -->
<!-- - Deprecated feature 1 -->
